### PR TITLE
Disable scrolling when mobile navbar is open

### DIFF
--- a/frontend/src/Components/Navbar/Navbar.module.scss
+++ b/frontend/src/Components/Navbar/Navbar.module.scss
@@ -151,7 +151,7 @@ $navbar-height: 60px;
 /* Mobile popup navigation */
 
 #mobile_popup_container {
-  position: absolute;
+  position: fixed;
   top: 60px;
   left: 0;
   width: 100vw;

--- a/frontend/src/Components/Navbar/Navbar.tsx
+++ b/frontend/src/Components/Navbar/Navbar.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink as Link, useNavigate } from 'react-router-dom';
 import { logout } from '~/api';
@@ -11,9 +10,10 @@ import { STATUS } from '~/http_status_codes';
 import { KEY, LANGUAGES } from '~/i18n/constants';
 import { ROUTES } from '~/routes';
 import styles from './Navbar.module.scss';
+import { useGlobalContext } from '../../GlobalContextProvider';
 
 export function Navbar() {
-  const [mobileNavigation, setMobileNavigation] = useState(false);
+  const { mobileNavigation, setMobileNavigation } = useGlobalContext();
   const { t, i18n } = useTranslation();
   const { user, setUser } = useAuthContext();
   const navigate = useNavigate();

--- a/frontend/src/GlobalContextProvider.tsx
+++ b/frontend/src/GlobalContextProvider.tsx
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { getCsrfToken } from '~/api';
 import { useAuthContext } from '~/AuthContext';
-import { THEME, ThemeValue, THEME_KEY, XCSRFTOKEN } from '~/constants';
+import { THEME, ThemeValue, THEME_KEY, XCSRFTOKEN, MOBILE_NAVIGATION_OPEN } from '~/constants';
 import { Children, SetState } from '~/types';
 
 /**
@@ -12,6 +12,8 @@ type GlobalContextProps = {
   theme: ThemeValue;
   setTheme: SetState<ThemeValue>;
   switchTheme: () => ThemeValue;
+  mobileNavigation: boolean;
+  setMobileNavigation: SetState<boolean>;
 };
 
 /**
@@ -49,6 +51,7 @@ export function GlobalContextProvider({ children }: GlobalContextProviderProps) 
   const initialTheme = storedTheme || detectedTheme;
 
   const [theme, setTheme] = useState<ThemeValue>(initialTheme);
+  const [mobileNavigation, setMobileNavigation] = useState(false);
   const { user } = useAuthContext();
 
   // Stuff to do on first render.
@@ -72,6 +75,15 @@ export function GlobalContextProvider({ children }: GlobalContextProviderProps) 
     }
   }
 
+  // Update body classes when mobile navigation opens/closes
+  useEffect(() => {
+    if (mobileNavigation) {
+      document.body.classList.add(MOBILE_NAVIGATION_OPEN);
+    } else {
+      document.body.classList.remove(MOBILE_NAVIGATION_OPEN);
+    }
+  }, [mobileNavigation]);
+
   // Update body classes when theme changes.
   useEffect(() => {
     if (theme === THEME.DARK) {
@@ -94,9 +106,11 @@ export function GlobalContextProvider({ children }: GlobalContextProviderProps) 
 
   /** Populated global context values. */
   const globalContextValues: GlobalContextProps = {
-    theme: theme,
-    setTheme: setTheme,
-    switchTheme: switchTheme,
+    theme,
+    setTheme,
+    switchTheme,
+    mobileNavigation,
+    setMobileNavigation,
   };
 
   return <GlobalContext.Provider value={globalContextValues}>{children}</GlobalContext.Provider>;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -7,6 +7,9 @@ export const THEME = {
   LIGHT: 'theme-light',
 } as const;
 
+// Class added to body when mobile navigation is open
+export const MOBILE_NAVIGATION_OPEN = 'mobile-navigation-open';
+
 export type ThemeKey = keyof typeof THEME;
 export type ThemeValue = typeof THEME[ThemeKey];
 

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -37,6 +37,11 @@ body {
   width: 100vw;
   height: 100vh;
   background-color: $white;
+
+  // Disable scrolling when mobile navbar is open
+  &.mobile-navigation-open {
+    overflow: hidden;
+  }
 }
 
 #root {


### PR DESCRIPTION
Notable changes:
* Move "mobile navbar open" state to global context
* Change mobile navbar container position to fixed
* Add `mobile-navigation-open` CSS class to body when navbar is open. The class sets overflow to hidden