### PR TITLE
Improve docker setup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,60 +1,36 @@
 # Use same version as defined in .python-version.
 FROM python:3.11.0-slim-bullseye
 
-# Update Ubuntu Software repository.
-RUN apt update -y \
-    && apt upgrade -y \
-    && apt install -y --no-install-recommends git build-essential procps curl file git nano sudo ncdu gcc postgresql libpq-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-### Environment variables. ###
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
-ENV PIPENV_VENV_IN_PROJECT=1
-# Docker should configure env vars in '.docker.env'.
-ENV PIPENV_DONT_LOAD_ENV=1
-
-# Set working directory.
-WORKDIR /app
-
-RUN echo 'alias la="ls -la"' >> ~/.bashrc
-
-# Upgrade pip.
-RUN python -m pip install --upgrade pip
-
-# Install pipenv.
-RUN python -m pip install pipenv
-
-# Copy dependency files into workdir (optimise docker cache layers).
-COPY Pipfile Pipfile.lock ./
-
-# Install virtual environment.
-RUN python -m pipenv install --dev --deploy
-
-# Copy rest of the project into image.
-COPY . .
-
-# Expose port for django and debugpy.
+ENV PYTHONUNBUFFERED 1
 EXPOSE 8000
 EXPOSE 5678
 
-# Update static and migration on each startup.
-ENTRYPOINT ["/app/entrypoint.sh"]
+# Alias
+RUN echo 'alias la="ls -la"' >> ~/.bashrc
 
-# Final command.
-# CMD ["python", "-m", "pipenv", "run", "python", "manage.py", "runserver", "0.0.0.0:8000"]
-CMD [ \
-  "python", \
-  "-m", \
-  "pipenv", \
-  "run", \
-  "gunicorn", \
-  "--bind=0.0.0.0:8000", \
-  "--forwarded-allow-ips=*", \
-  "--pythonpath=/app", \
-  "--workers=1", \
-  "--timeout=120", \
-  "--worker-class=gthread", \
-  "--threads=5", \
-  "root.wsgi:application" \
-]
+# Useful alias shortcuts for django
+RUN echo 'alias migrate="pipenv run python /app/manage.py migrate"' >> ~/.bashrc
+RUN echo 'alias makemigrations="pipenv run python /app/manage.py makemigrations"' >> ~/.bashrc
+RUN echo 'alias seed="pipenv run python /app/manage.py seed"' >> ~/.bashrc
+RUN echo 'alias collectstatic="pipenv run python /app/manage.py collectstatic --noinput"' >> ~/.bashrc
+
+# Make directories
+RUN mkdir /app
+WORKDIR /app
+
+# Docker should configure env vars in '.docker.env'.
+ENV PIPENV_DONT_LOAD_ENV=1
+
+# Copy dependencies
+COPY Pipfile Pipfile.lock ./
+
+# Install virtual environment.
+RUN python -m pip install pipenv
+RUN python -m pipenv install --dev --deploy
+
+# Copy remaining
+COPY . /app
+
+# Start
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["python", "-m", "pipenv", "run", "python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/backend/root/settings/base.py
+++ b/backend/root/settings/base.py
@@ -27,11 +27,6 @@ environ.Env.read_env(env_file=BASE_DIR / '.env', overwrite=False)
 
 AUTH_USER_MODEL = 'samfundet.User'
 
-### Print variables ###
-print(f'=== {BASE_DIR=}')  # noqa: T201
-print(f"=== {os.environ['DJANGO_SETTINGS_MODULE']=}")  # noqa: T201
-### End: Print variables ###
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 ALLOWED_HOSTS: list[str] = []

--- a/backend/root/settings/base.py
+++ b/backend/root/settings/base.py
@@ -197,7 +197,6 @@ INSTALLED_APPS += [
 ################## LOGGING ##################
 
 # pylint: disable=wrong-import-position,wrong-import-order
-import logging.config  # noqa: E402
 
 from root.utils.json_formatter import JsonFormatter  # noqa: E402
 from root.custom_classes.request_context_filter import RequestContextFilter  # noqa: E402
@@ -303,7 +302,6 @@ LOGGING = {
         },
 }
 
-logging.config.dictConfig(LOGGING)
 
 # Quick fix for avoiding concurrency issues related to db access
 # Note: this might not be an ideal solution. See these links for information

--- a/backend/root/settings/dev.py
+++ b/backend/root/settings/dev.py
@@ -64,3 +64,10 @@ DATABASES = {
     }
 }
 ### End: Database ###
+
+# Clean console logging in development (pretty stack trace)
+LOGGING['loggers'][''] = {
+    'handlers': ['console'], 
+    'level': 'DEBUG',
+    'propagate': True,
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
     ports:
       - '8000:8000' # Quotes are required. django
       - '5678:5678' # Quotes are required. debugpy
-
   # Mount sync on OSX Docker VM is really slow. Run on host machine instead.
   frontend:
     build: ./frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
   ### Backend Django ###
   backend:
     build: ./backend # Build in the context of this directory (meaning: use Dockerfile, .dockerignore etc.)
+    image: samfundet-backend
     volumes:
       - ./backend:/app # Mount backend folder to docker image
       - ignore_venv:/app/.venv # Ignore local virtual environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,43 @@ services:
     ports:
       - '3000:3000'
 
+  ### Storybook React ###
+  storybook:
+    build: ./frontend # Build in the context of this directory (meaning: use Dockerfile, .dockerignore etc.)
+    image: samfundet-frontend-storybook
+    volumes:
+      - ./frontend/src:/app/src # Share project code between host machine and container to enable reload on changes.
+    env_file:
+      - ./frontend/.env.docker # Environment for frontend docker
+    environment:
+      - IS_DOCKER=yes
+      - CHOKIDAR_USEPOLLING=true # Might not be needed. Used for hot reload.
+    ports:
+      - '6006:6006'
+    command: yarn run storybook
+
+  ### Welcome Splash ###
+  welcome:
+    image: alpine:latest # Minimal image (~ 5MB)
+    command: >
+      /bin/ash -c "sleep 5 && printf '
+      \n
+      -------------------------------------------------------------------------------
+      \n\n\e[31m
+      ███████╗ █████╗ ███╗   ███╗███████╗██╗   ██╗███╗   ██╗██████╗ ███████╗████████╗\n\e[31m
+      ██╔════╝██╔══██╗████╗ ████║██╔════╝██║   ██║████╗  ██║██╔══██╗██╔════╝╚══██╔══╝\n\e[31m
+      ███████╗███████║██╔████╔██║█████╗  ██║   ██║██╔██╗ ██║██║  ██║█████╗     ██║   \n\e[31m
+      ╚════██║██╔══██║██║╚██╔╝██║██╔══╝  ██║   ██║██║╚██╗██║██║  ██║██╔══╝     ██║   \n\e[31m
+      ███████║██║  ██║██║ ╚═╝ ██║██║     ╚██████╔╝██║ ╚████║██████╔╝███████╗   ██║   \n\e[31m
+      ╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚═╝      ╚═════╝ ╚═╝  ╚═══╝╚═════╝ ╚══════╝   ╚═╝   \n
+        
+      \e[34m Backend:    http://localhost:8000\n
+      \e[34mFrontend:   http://localhost:3000\n
+      \e[34mStorybook:  http://localhost:6006\n
+      \n\e[0m
+      -------------------------------------------------------------------------------\n\n
+      '"
+
 ### Ignore volume names ###
 volumes:
   ignore_venv:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,39 +1,37 @@
 version: '3.9'
 
-### Bases ###
-x-backend-base: &backend-base
-  build: ./backend # Build in the context of this directory (meaning: use Dockerfile, .dockerignore etc.)
-  volumes:
-    - ./backend:/app
-    - ignore_venv:/app/.venv
-  env_file:
-    - ./backend/.docker.env
-  environment:
-    - IS_DOCKER=yes
-### End: Bases ###
-
 ### Services ###
 services:
+
+  ### Backend Django ###
   backend:
-    <<: *backend-base
+    build: ./backend # Build in the context of this directory (meaning: use Dockerfile, .dockerignore etc.)
+    volumes:
+      - ./backend:/app # Mount backend folder to docker image
+      - ignore_venv:/app/.venv # Ignore local virtual environment
+    env_file:
+      - ./backend/.docker.env # Environment for backend docker
+    environment:
+      - IS_DOCKER=yes
     ports:
       - '8000:8000' # Quotes are required. django
       - '5678:5678' # Quotes are required. debugpy
-  # Mount sync on OSX Docker VM is really slow. Run on host machine instead.
+
+  ### Frontend React ###
   frontend:
-    build: ./frontend
+    build: ./frontend # Build in the context of this directory (meaning: use Dockerfile, .dockerignore etc.)
     image: samfundet-frontend
     volumes:
       - ./frontend/src:/app/src # Share project code between host machine and container to enable reload on changes.
     env_file:
-      - ./frontend/.env.docker
+      - ./frontend/.env.docker # Environment for frontend docker
     environment:
       - IS_DOCKER=yes
       - CHOKIDAR_USEPOLLING=true # Might not be needed. Used for hot reload.
     ports:
       - '3000:3000'
-### End: Services ###
 
+### Ignore volume names ###
 volumes:
   ignore_venv:
   ignore_database:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,7 @@ COPY package.json yarn.lock ./
 # Require up to date package.json and yarn.lock, fail otherwise.
 RUN yarn install --frozen-lockfile
 
-COPY . .
+COPY . /app
 
 EXPOSE 3000
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,20 +1,15 @@
 FROM node:19.3-bullseye-slim
-
-# Update packages and install Cypress dependencies.
-RUN apt update -y \
-    && apt upgrade -y \
-    && apt install -y --no-install-recommends libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb \
-    && rm -rf /var/lib/apt/lists/*
-
+EXPOSE 3000
 WORKDIR /app
 
+# Copy package file to docker
 COPY package.json yarn.lock ./
 
 # Require up to date package.json and yarn.lock, fail otherwise.
 RUN yarn install --frozen-lockfile
 
+# Copy remaining files
 COPY . /app
 
-EXPOSE 3000
-
+# Start dev server
 CMD ["yarn", "start:docker", "--host", "0.0.0.0", "--port", "3000"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,4 @@
+# For cypress dependencies use cypress image, eg. cypress/base:19
 FROM node:19.3-bullseye-slim
 EXPOSE 3000
 WORKDIR /app

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "dev": "yarn run start",
     "build": "vite build",
     "preview": "vite preview",
-    "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006 -s public",
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006 -s public --quiet --no-open --ci",
     "storybook-dev": "start-storybook -p 6006 -s public",
     "build-storybook": "NODE_OPTIONS=--openssl-legacy-provider build-storybook -s public",
     "build-storybook-dev": "build-storybook -s public",


### PR DESCRIPTION
- Improves build times for backend and frontend. On my system:
   - Backend:  115.9s -> 25.6s (4.5x faster)
   - Frontend: 262.1s -> 206.3s (1.3x faster) 
- Optimizes docker layering to prevent too many rebuilds of lower layers
- Add nice shortcuts in docker container for seeding/migrating etc
- Simplifies docker-compose and dockerfiles
- Add storybook to docker-compose  
   - No need to run manually anymore. Will of course not be needed in prod later on.
- Add nice little welcome splash
- Changes logging in backend dev environment
   - Stack traces were basically unreadable. Nice for prod, but not for dev. 
   
A lot of speed is gained by removing apt installs. These really go against what I think docker is great for, as it could break the project without changing anything. Instead we should use specific dependency versions and docker images if possible. Will have to look into this more when we enable cypress again.


