### PR TITLE
497 frontpage skeleton

### DIFF
--- a/frontend/src/Components/Carousel/Carousel.module.scss
+++ b/frontend/src/Components/Carousel/Carousel.module.scss
@@ -1,5 +1,3 @@
-/* stylelint-disable */
-
 @import 'src/constants';
 
 @import 'src/mixins';
@@ -48,6 +46,7 @@
     }
   }
   @include for-mobile-only {
+    /* stylelint-disable-next-line declaration-no-important */
     scroll-snap-align: center !important;
     scroll-margin-left: $primary-content-mobile-padding;
     scroll-margin-right: $primary-content-mobile-padding;
@@ -62,26 +61,24 @@
     // Disabled for now
     // display: flex;
     display: none;
-
     justify-content: center;
     align-items: center;
-
     width: 2em;
     height: 2em;
-    background-color: #555;
+    background-color: #555555;
     border-radius: 100%;
     color: white;
-
     position: relative;
     top: calc(50% - 1em);
     z-index: 10000;
-
     transition: 0.2s;
     cursor: pointer;
 
+    /* stylelint-disable-next-line selector-max-class, max-nesting-depth */
     &.left {
       left: 1em;
     }
+    /* stylelint-disable-next-line selector-max-class, max-nesting-depth */
     &.right {
       right: 3em;
     }
@@ -95,7 +92,7 @@
 
 .header {
   font-size: 1.5em;
-  font-weight: bold;
+  font-weight: 700;
   text-align: left;
   margin-left: $primary-content-wide-padding;
   width: $primary-content-width-wide;

--- a/frontend/src/Components/Carousel/Carousel.module.scss
+++ b/frontend/src/Components/Carousel/Carousel.module.scss
@@ -1,130 +1,107 @@
 /* stylelint-disable */
 
-@import "src/constants";
+@import 'src/constants';
 
-@import "src/mixins";
+@import 'src/mixins';
 
-
-.carousel {
+.scroller {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  max-width: 100vw;
-  overflow: visible;
+  flex-direction: row;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
 
-  padding-bottom: 1em; 
-  padding-top: 1em; 
+  // For visibility above (shadows on content etc)
+  padding-top: 10px;
 
-  .header {
-    font-size: 1.5em;
-    font-weight: bold;
-    text-align: left;
-    width: $primary-content-width-wide;
-    max-width: 100%;
+  /* Hide scrollbar for IE, Edge and Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
 
-    @include for-mobile-only {
-      width: $primary-content-width-mobile;
-    }
-
+  // Don't snap on mobile? Not sure what's best
+  @include for-mobile-only {
+    scroll-snap-type: none;
   }
 
-  .container {
-    display: flex;
-    flex-direction: row;
-    width: 100%;
-    max-width: 100%;
-    overflow: visible;
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
 
-    .scroller {
-      display: flex;
-      flex-direction: row;
-      overflow-x: scroll;
-      overflow-y: hidden;
-      scroll-snap-type: x mandatory;
+.itemContainer {
+  scroll-snap-align: start;
+  scroll-snap-type: mandatory;
+  scroll-margin-left: $primary-content-wide-padding;
+  overflow: visible;
 
-      // For visibility above (shadows on content etc)
-      padding-top: 10px;
+  &:first-child {
+    padding-left: $primary-content-wide-padding;
+    @include for-mobile-only {
+      padding-left: $primary-content-mobile-padding;
+    }
+  }
+  &:last-child {
+    padding-right: $primary-content-wide-padding;
+    @include for-mobile-only {
+      padding-right: $primary-content-mobile-padding;
+    }
+  }
+  @include for-mobile-only {
+    scroll-snap-align: center !important;
+    scroll-margin-left: $primary-content-mobile-padding;
+    scroll-margin-right: $primary-content-mobile-padding;
+  }
+}
 
-      /* Hide scrollbar for IE, Edge and Firefox */
-      -ms-overflow-style: none; /* IE and Edge */
-      scrollbar-width: none; /* Firefox */
-      
-      // Don't snap on mobile? Not sure what's best
-      @include for-mobile-only {
-        scroll-snap-type: none;
-      }
+.navContainer {
+  width: 0;
+  overflow: visible;
 
-      .itemContainer {
-        scroll-snap-align: start;
-        scroll-snap-type: mandatory;
-        scroll-margin-left: $primary-content-wide-padding;
-        overflow: visible;
+  .button {
+    // Disabled for now
+    // display: flex;
+    display: none;
 
-        &:first-child {
-          padding-left: $primary-content-wide-padding;
-          @include for-mobile-only {
-            padding-left: $primary-content-mobile-padding;
-          }
-        }
-        &:last-child {
-          padding-right: $primary-content-wide-padding;
-          @include for-mobile-only {
-            padding-right: $primary-content-mobile-padding;
-          }
-        }
-        @include for-mobile-only {
-          scroll-snap-align: center !important;
-          scroll-margin-left: $primary-content-mobile-padding;
-          scroll-margin-right: $primary-content-mobile-padding;
-        }
+    justify-content: center;
+    align-items: center;
 
-      }
-      
+    width: 2em;
+    height: 2em;
+    background-color: #555;
+    border-radius: 100%;
+    color: white;
+
+    position: relative;
+    top: calc(50% - 1em);
+    z-index: 10000;
+
+    transition: 0.2s;
+    cursor: pointer;
+
+    &.left {
+      left: 1em;
+    }
+    &.right {
+      right: 3em;
     }
 
-    /* Hide scrollbar for Chrome, Safari and Opera */
-    .scroller::-webkit-scrollbar {
-      display: none;
+    &:hover {
+      filter: brightness(110%);
+      transform: scale(1.05);
     }
+  }
+}
 
-    .navContainer {
-      width: 0;
-      overflow: visible;
+.header {
+  font-size: 1.5em;
+  font-weight: bold;
+  text-align: left;
+  margin-left: $primary-content-wide-padding;
+  width: $primary-content-width-wide;
+  max-width: 100%;
 
-      .button {
-        // Disabled for now
-        // display: flex;
-        display: none;
-
-        justify-content: center;
-        align-items: center;
-
-        width: 2em;
-        height: 2em;
-        background-color: #555;
-        border-radius: 100%;
-        color: white;
-
-        position: relative;
-        top: calc(50% - 1em);
-        z-index: 10000;
-
-        transition: 0.2s;
-        cursor: pointer;
-
-        &.left {
-          left: 1em;
-        }
-        &.right {
-          right: 3em;
-        }
-
-        &:hover {
-          filter: brightness(110%);
-          transform: scale(1.05);
-        }
-      }
-    }
+  @include for-mobile-only {
+    width: $primary-content-width-mobile;
   }
 }

--- a/frontend/src/Components/Carousel/Carousel.tsx
+++ b/frontend/src/Components/Carousel/Carousel.tsx
@@ -1,14 +1,17 @@
 import classnames from 'classnames';
+import { ReactNode } from 'react';
+import { Skeleton } from '~/Components/Skeleton';
 import { Children } from '~/types';
 import styles from './Carousel.module.scss';
 
 type CarouselProps = {
   children: Array<Children>;
-  header?: string;
+  header?: ReactNode;
   spacing?: number;
+  className: string;
 };
 
-export function Carousel({ children, header, spacing }: CarouselProps) {
+export function Carousel({ children, className, header = <Skeleton width={'8em'} />, spacing }: CarouselProps) {
   const wrappedChildren = children.map((child: Children, idx: number) => {
     return (
       <div className={styles.itemContainer} key={idx}>
@@ -18,9 +21,9 @@ export function Carousel({ children, header, spacing }: CarouselProps) {
   });
 
   return (
-    <div className={styles.carousel}>
-      {header && <div className={styles.header}>{header}</div>}
-      <div className={styles.container}>
+    <div className={className}>
+      <div className={styles.header}>{header}</div>
+      <div>
         <div className={styles.navContainer}>
           <div className={classnames(styles.button, styles.left)}>{'<'}</div>
         </div>

--- a/frontend/src/Components/Carousel/Carousel.tsx
+++ b/frontend/src/Components/Carousel/Carousel.tsx
@@ -8,7 +8,7 @@ type CarouselProps = {
   children: Array<Children>;
   header?: ReactNode;
   spacing?: number;
-  className: string;
+  className?: string;
 };
 
 export function Carousel({ children, className, header = <Skeleton width={'8em'} />, spacing }: CarouselProps) {

--- a/frontend/src/Components/ContentCard/ContentCard.module.scss
+++ b/frontend/src/Components/ContentCard/ContentCard.module.scss
@@ -6,9 +6,9 @@ $mobile-width: $primary-content-width-mobile;
 $background-light: #b7afaf;
 $background-dark: #2e2b2b;
 
+// Must match the sizing of .container.
 .skeleton_wrapper {
-  // display: flex;
-  width: calc(100vw - 5em);
+  width: $primary-content-width-wide;
   height: 24em;
   border-radius: 1em;
 

--- a/frontend/src/Components/ContentCard/ContentCard.module.scss
+++ b/frontend/src/Components/ContentCard/ContentCard.module.scss
@@ -6,18 +6,22 @@ $mobile-width: $primary-content-width-mobile;
 $background-light: #b7afaf;
 $background-dark: #2e2b2b;
 
+.skeleton_wrapper {
+  // display: flex;
+  width: calc(100vw - 5em);
+  height: 24em;
+  border-radius: 1em;
+
+  @include for-mobile-only {
+    width: $mobile-width;
+    height: 12em;
+  }
+}
+
 .container {
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  justify-content: stretch;
-  gap: 0.25em;
   height: 24em;
   width: $primary-content-width-wide;
-  overflow: visible;
-  padding-top: 1em;
-  padding-bottom: 1em;
-  max-width: 100%;
 
   @include for-mobile-only {
     width: $mobile-width;
@@ -95,6 +99,7 @@ $background-dark: #2e2b2b;
 
 .info_description {
   color: $grey-1;
+
   @include theme-dark {
     color: $grey-3;
   }

--- a/frontend/src/Components/ContentCard/ContentCard.tsx
+++ b/frontend/src/Components/ContentCard/ContentCard.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@iconify/react';
 import classnames from 'classnames';
-import { useId } from 'react';
+import { ReactNode, useId } from 'react';
+import { Skeleton } from '~/Components';
 import { useScreenCenterOffset } from '~/hooks';
 import { backgroundImageFromUrl } from '~/utils';
 import { Button } from '../Button';
@@ -8,19 +9,21 @@ import styles from './ContentCard.module.scss';
 
 type ContentCardProps = {
   className?: string;
-  title?: string;
-  description?: string;
+  title?: ReactNode;
+  description?: ReactNode;
   buttonText?: string;
   url?: string;
   imageUrl?: string;
+  isSkeleton?: boolean;
 };
 
 export function ContentCard({
   className,
-  title = 'Missing title',
-  description,
+  title = <Skeleton />,
+  description = <Skeleton />,
   buttonText,
   url,
+  isSkeleton,
   imageUrl,
 }: ContentCardProps) {
   const id = useId();
@@ -35,10 +38,21 @@ export function ContentCard({
     window.location.href = url;
   }
 
+  if (isSkeleton) {
+    return (
+      <div className={styles.skeleton_wrapper}>
+        <Skeleton height={'100%'} borderRadius={'1em'} />
+      </div>
+    );
+  }
+
   return (
     <div className={classnames(styles.container, className)} style={{ transform: containerTransform }} id={id}>
       <div className={styles.card}>
+        {/* Image */}
         <div className={styles.card_image} style={backgroundImageFromUrl(imageUrl)} />
+
+        {/* Text */}
         <div className={styles.card_info} style={{ transform: infoTransform }}>
           <div className={styles.info_header}>{title}</div>
           <div className={styles.info_description}>{description}</div>

--- a/frontend/src/Components/ImageCard/ImageCard.module.scss
+++ b/frontend/src/Components/ImageCard/ImageCard.module.scss
@@ -33,10 +33,13 @@ $description-color: #aaaaaa;
   flex-basis: 100%;
   transition: 0.2s;
   box-shadow: 0 0 5px 3px $black-t10;
-  background-image: url('~/assets/banner-sample-2.jpeg');
   background-size: cover;
   background-position: center;
   cursor: pointer;
+}
+
+.default_image {
+  background-image: url('~/assets/banner-sample-2.jpeg');
 }
 
 .bottom_label {

--- a/frontend/src/Components/ImageCard/ImageCard.module.scss
+++ b/frontend/src/Components/ImageCard/ImageCard.module.scss
@@ -28,7 +28,6 @@ $description-color: #aaaaaa;
 }
 
 .card {
-  background-color: $card-background;
   border-radius: 1em;
   flex-basis: 100%;
   transition: 0.2s;

--- a/frontend/src/Components/ImageCard/ImageCard.tsx
+++ b/frontend/src/Components/ImageCard/ImageCard.tsx
@@ -1,4 +1,6 @@
-import classnames from 'classnames';
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+import { Skeleton } from '~/Components';
 import { Children } from '~/types';
 import { backgroundImageFromUrl } from '~/utils';
 import { Link } from '../Link';
@@ -7,37 +9,66 @@ import styles from './ImageCard.module.scss';
 
 type ImageCardProps = {
   className?: string;
-  title?: string;
-  description?: string;
+  title?: ReactNode;
+  description?: ReactNode;
   date?: string | Date;
   url?: string;
   imageUrl?: string;
   localImage?: boolean; // Local image in frontend assets.
   compact?: boolean;
+  isSkeleton?: boolean;
   children?: Children;
 };
 
 export function ImageCard({
   className,
-  title,
-  description,
+  title = <Skeleton width={'8em'} />,
+  description = <Skeleton width={'100%'} />,
   date,
   url = '#',
   imageUrl,
   compact,
+  isSkeleton,
   children,
 }: ImageCardProps) {
+  const containerStyle = classNames(styles.container, compact && styles.compact, className);
+  const cardStyle = styles.card;
+  const bottomLabelStyle = styles.bottom_label;
+  const bottomDescriptionStyle = styles.bottom_description;
+
+  if (isSkeleton) {
+    return (
+      <div className={containerStyle}>
+        <Skeleton className={cardStyle} borderRadius={'1em'} height={compact ? '7.3em' : '13em'} />
+
+        <div className={bottomLabelStyle}>
+          <div style={{ width: '40%' }}>
+            <Skeleton />
+          </div>
+          <div style={{ width: '40%' }}>
+            <Skeleton />
+          </div>
+        </div>
+
+        <div className={bottomDescriptionStyle}>
+          <div style={{ width: '100%' }}>{!compact && <Skeleton />}</div>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className={classnames(styles.container, compact && styles.compact, className)}>
-      <Link url={url} className={styles.card} style={backgroundImageFromUrl(imageUrl)}>
+    <div className={containerStyle}>
+      <Link url={url} className={classNames(cardStyle, styles.default_image)} style={backgroundImageFromUrl(imageUrl)}>
         {children}
       </Link>
 
-      <div className={styles.bottom_label}>
+      <div className={bottomLabelStyle}>
         <div>{title}</div>
         <div className={styles.date_label}>{date && <TimeDisplay timestamp={date} displayType="event" />}</div>
       </div>
-      <div className={styles.bottom_description}>
+
+      <div className={bottomDescriptionStyle}>
         {description}
         &nbsp;
       </div>

--- a/frontend/src/Components/Navbar/Navbar.module.scss
+++ b/frontend/src/Components/Navbar/Navbar.module.scss
@@ -26,21 +26,23 @@ $navbar-link-dark-hover-gradient-bottom: #000000;
 $navbar-link-transparent-hover-gradient-top: rgba(255, 255, 255, 0.1);
 $navbar-link-transparent-hover-gradient-bottom: rgba(255, 255, 255, 0);
 
+// QUESTION: Does this have any effect?
 /* Outer container in navbar layout */
-.navbar_layout_outer {
-  min-height: 100%;
-  max-height: 100%;
-  height: 100%;
-}
+// .navbar_layout_outer {
+//   min-height: 100%;
+//   max-height: 100%;
+//   height: 100%;
+// }
 
+// QUESTION: Does this have any effect?
 /* Inner container with padding */
-.navbar_layout_inner {
-  padding-top: $navbar-height;
-  min-height: 100%;
-  max-height: 100%;
-  height: 100%;
-  width: 100%;
-}
+// .navbar_layout_inner {
+// padding-top: $navbar-height;
+// min-height: 100%;
+// max-height: 100%;
+// height: 100%;
+// width: 100%;
+// }
 
 /* Content padding */
 .navbar_padding {

--- a/frontend/src/Components/Skeleton/Skeleton.tsx
+++ b/frontend/src/Components/Skeleton/Skeleton.tsx
@@ -1,7 +1,18 @@
 import OriginalSkeleton, { SkeletonProps } from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
+import { useIsDarkTheme } from '~/hooks';
+import { COLORS } from '~/types';
 
 /** Simple wrapper around package to import required css file. */
 export function Skeleton(props: SkeletonProps) {
-  return <OriginalSkeleton {...props} />;
+  const isDarkTheme = useIsDarkTheme();
+  const baseColor = isDarkTheme ? COLORS.theme_dark_input_bg : '#ddd';
+  const highlightColor = isDarkTheme ? '#333' : '#eee';
+  return (
+    <OriginalSkeleton
+      {...props}
+      baseColor={props.baseColor || baseColor}
+      highlightColor={props.highlightColor || highlightColor}
+    />
+  );
 }

--- a/frontend/src/Components/Skeleton/Skeleton.tsx
+++ b/frontend/src/Components/Skeleton/Skeleton.tsx
@@ -8,11 +8,15 @@ export function Skeleton(props: SkeletonProps) {
   const isDarkTheme = useIsDarkTheme();
   const baseColor = isDarkTheme ? COLORS.theme_dark_input_bg : '#ddd';
   const highlightColor = isDarkTheme ? '#333' : '#eee';
+  const defaultBorder = isDarkTheme ? '1px solid black' : '1px solid #ccc';
+  const style = props.style?.border ? props.style : { ...props.style, border: defaultBorder };
+
   return (
     <OriginalSkeleton
       {...props}
       baseColor={props.baseColor || baseColor}
       highlightColor={props.highlightColor || highlightColor}
+      style={style}
     />
   );
 }

--- a/frontend/src/Pages/HomePage/HomePage.module.scss
+++ b/frontend/src/Pages/HomePage/HomePage.module.scss
@@ -5,21 +5,6 @@
 
 @import 'src/mixins';
 
-.container {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  max-width: 100vw;
-  margin: 0;
-}
-
-.logo {
-  width: 30em;
-  margin-bottom: 1em;
-}
-
 .splash {
   width: 100vw;
   min-height: 60vh;
@@ -52,49 +37,5 @@
 .content {
   position: relative;
   top: -$navbar-height;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  max-width: 100%;
-}
-
-.inner_content {
-  width: 100%;
-  max-width: 800px;
-}
-
-.header {
-  font-size: 2em;
-  font-weight: 700;
-  text-align: center;
-  padding-top: 30px;
-}
-
-.button_row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
-  margin-top: 20px;
-  justify-content: center;
-}
-
-.text {
-  text-align: left;
-  margin-top: 50px;
-}
-
-.button {
-  display: block;
-  margin-top: 1em;
-  padding: 1em;
-  background-color: rgb(160 48 51);
-  color: white;
-  border-radius: 0.2em;
-
-  &:hover {
-    filter: brightness(110%);
-    transform: scale(1.01);
-    transition: 0.2s;
-  }
+  // max-width: 100%; // QUESTION: Why is this needed?
 }

--- a/frontend/src/Pages/HomePage/HomePage.tsx
+++ b/frontend/src/Pages/HomePage/HomePage.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
-import { getHomeData } from '~/api';
-import splash from '~/assets/banner-sample.jpg';
 import { ToggleSwitch } from '~/Components';
-import { HomePageElementDto } from '~/dto';
 import { useGlobalContext } from '~/GlobalContextProvider';
 import { EventCarousel, LargeCard } from '~/Pages/HomePage/components';
+import { getHomeData } from '~/api';
+import splash from '~/assets/banner-sample.jpg';
+import { HomePageElementDto } from '~/dto';
 import { Children } from '~/types';
 import styles from './HomePage.module.scss';
 
@@ -12,34 +12,49 @@ export function HomePage() {
   const [elements, setHomeElements] = useState<HomePageElementDto[]>([]);
 
   const { mirrorDimension, toggleMirrorDimension } = useGlobalContext();
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    getHomeData().then((elements: HomePageElementDto[]) => {
-      setHomeElements(elements);
-    });
+    getHomeData()
+      .then((elements: HomePageElementDto[]) => {
+        setHomeElements(elements);
+      })
+      .finally(() => setIsLoading(false));
   }, []);
 
-  function renderElement(key: number, element: HomePageElementDto): Children | undefined {
+  function renderElement(key: number, element: HomePageElementDto): Children {
     switch (element.variation) {
       case 'carousel':
         return <EventCarousel key={key} element={element} />;
       case 'large-card':
         return <LargeCard key={key} element={element} />;
-
-        console.log(`Unknown home page element kind '${element.variation}'`);
-        return undefined;
     }
+    console.error(`Unknown home page element kind '${element.variation}'`);
+    return <></>;
   }
 
+  const skeleton = (
+    <>
+      <LargeCard />
+      <EventCarousel skeletonCount={6} />
+    </>
+  );
+
   return (
-    <div className={styles.container}>
+    <>
       <img src={splash} alt="Splash" className={styles.splash} />
       <div className={styles.splash_fade}></div>
       <div className={styles.content}>
         {/*<SplashHeaderBox />*/}
+
+        {/* Toggle mirror dimension, TODO: move to PreferencePage. */}
         <ToggleSwitch checked={mirrorDimension} onChange={toggleMirrorDimension} />
+
+        {isLoading && skeleton}
+
+        {/* Render elements for frontpage. */}
         {elements.map((el: HomePageElementDto, index) => renderElement(index, el))}
       </div>
-    </div>
+    </>
   );
 }

--- a/frontend/src/Pages/HomePage/components/EventCarousel/EventCarousel.tsx
+++ b/frontend/src/Pages/HomePage/components/EventCarousel/EventCarousel.tsx
@@ -10,15 +10,29 @@ import { hasPerm } from '~/utils';
 import styles from './EventCarousel.module.scss';
 
 type EventCarouselProps = {
-  element: HomePageElementDto;
+  skeletonCount?: number;
+  element?: HomePageElementDto;
 };
 
-export function EventCarousel({ element }: EventCarouselProps) {
+const spacing = 1.5;
+
+export function EventCarousel({ element, skeletonCount = 0 }: EventCarouselProps) {
   const { user } = useAuthContext();
   const isStaff = user?.is_staff;
+  const wrapperClass = styles.wrapper;
+
+  if (!element) {
+    return (
+      <Carousel className={wrapperClass} spacing={spacing}>
+        {Array.from({ length: skeletonCount }).map((_, i) => (
+          <ImageCard key={i} isSkeleton />
+        ))}
+      </Carousel>
+    );
+  }
 
   return (
-    <Carousel header={element.title_nb} spacing={1.5}>
+    <Carousel className={wrapperClass} header={element.title_nb} spacing={spacing}>
       {element.events.map((event: EventDto) => {
         const url = reverse({ pattern: ROUTES.frontend.event, urlParams: { id: event.id } });
         const editUrl = reverse({ pattern: ROUTES.frontend.admin_events_edit, urlParams: { id: event.id } });

--- a/frontend/src/Pages/HomePage/components/EventCarousel/EventCarousel.tsx
+++ b/frontend/src/Pages/HomePage/components/EventCarousel/EventCarousel.tsx
@@ -49,6 +49,7 @@ export function EventCarousel({ element, skeletonCount = 0 }: EventCarouselProps
             title={event.title_en}
             date={event.start_dt}
             imageUrl={BACKEND_DOMAIN + event.image_url}
+            description=""
             url={url}
           >
             <div className={styles.button_bar}>

--- a/frontend/src/Pages/HomePage/components/LargeCard/LargeCard.module.scss
+++ b/frontend/src/Pages/HomePage/components/LargeCard/LargeCard.module.scss
@@ -1,0 +1,8 @@
+@import 'src/constants';
+
+.layout {
+  display: flex;
+  justify-content: center;
+  margin-top: 1em;
+  margin-bottom: 1em;
+}

--- a/frontend/src/Pages/HomePage/components/LargeCard/LargeCard.tsx
+++ b/frontend/src/Pages/HomePage/components/LargeCard/LargeCard.tsx
@@ -4,21 +4,33 @@ import { HomePageElementDto } from '~/dto';
 import { reverse } from '~/named-urls';
 import { ROUTES } from '~/routes';
 import { dbT } from '~/utils';
+import styles from './LargeCard.module.scss';
 
 type LargeCardProps = {
-  element: HomePageElementDto;
+  element?: HomePageElementDto;
 };
 
 export function LargeCard({ element }: LargeCardProps) {
-  const event = element.events[0];
+  if (!element) {
+    return (
+      <div className={styles.layout}>
+        <ContentCard isSkeleton />
+      </div>
+    );
+  }
+
+  const event = element?.events[0];
   const url = reverse({ pattern: ROUTES.frontend.event, urlParams: { id: event.id } });
+
   return (
-    <ContentCard
-      title={dbT(element, 'title')}
-      description={dbT(element, 'description')}
-      imageUrl={BACKEND_DOMAIN + event.image_url}
-      url={url}
-      buttonText=""
-    />
+    <div className={styles.layout}>
+      <ContentCard
+        title={dbT(element, 'title')}
+        description={dbT(element, 'description')}
+        imageUrl={BACKEND_DOMAIN + event.image_url}
+        url={url}
+        buttonText=""
+      />
+    </div>
   );
 }

--- a/frontend/src/hooks.ts
+++ b/frontend/src/hooks.ts
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import { getTextItem } from '~/api';
 import { useAuthContext } from '~/AuthContext';
 import { useGlobalContext } from '~/GlobalContextProvider';
+import { getTextItem } from '~/api';
 import { Key } from '~/types';
 import { hasPerm, isTruthy } from '~/utils';
-import { desktopBpLower, mobileBpUpper } from './constants';
+import { THEME, desktopBpLower, mobileBpUpper } from './constants';
 import { TextItemDto } from './dto';
 import { LANGUAGES } from './i18n/constants';
 
@@ -170,4 +170,14 @@ export function useKeyValue(key: Key, checkTruthy?: boolean): string | boolean |
     return isTruthy(keyValue);
   }
   return keyValue;
+}
+
+export function useIsDarkTheme(): boolean {
+  const { theme } = useGlobalContext();
+  return theme === THEME.DARK;
+}
+
+export function useIsLightTheme(): boolean {
+  const { theme } = useGlobalContext();
+  return theme === THEME.LIGHT;
 }


### PR DESCRIPTION
- Fjernet en del styling som ikke så ut til å ha noen effekt.
- Redusert bruken av unødvendig flex på store scopes (påvirker mange child elements som Skeleton).
- Separert layout fra styling. Komponenter trenger ikke noe konsept om avstand fra andre elementer. Ansvaret delegeres til den som tar komponent i bruk.
- Hooks for nåværende theme.
- Forbedret Skeleton farger på ulike themes.
- Default Skeleton på visse komponenter ved manglende props.
- HomePage refaktorert til å vise Skeletons mens den laster inn data.
- Aktivert stylelint for Carousel.

<img width="1214" alt="image" src="https://user-images.githubusercontent.com/22004178/229393850-4cba4e21-46b1-49d9-b0a6-0e21898f2d22.png">

