### PR TITLE
Speedup seed scripts

### DIFF
--- a/backend/root/management/commands/seed_scripts/documents.py
+++ b/backend/root/management/commands/seed_scripts/documents.py
@@ -2,17 +2,19 @@ import os
 import random
 
 from django.core.files import File
+from django.db import transaction
 from django.utils import timezone
 
 from root.utils.samfundet_random import words
 from samfundet.models.general import Saksdokument
 
+COUNT = 100
 DAY_RANGE = 365 * 5
 CREATE_OFFSET = 30
 
 
 def seed():
-    count = 100
+
     cats = [
         Saksdokument.SaksdokumentCategory.FS_REFERAT,
         Saksdokument.SaksdokumentCategory.STYRET,
@@ -20,40 +22,46 @@ def seed():
         Saksdokument.SaksdokumentCategory.ARSBERETNINGER,
     ]
 
-    # Delete old data
-    Saksdokument.objects.all().delete()
-
-    # Load seed file
+    # Load file just once (much faster)
     data_path = os.path.join(os.path.dirname(__file__), 'seed_data')
-    with open(os.path.join(data_path, 'seed.pdf'), mode='rb') as seed_file:
-        for i in range(count):
-            name_no, name_en = words(2, include_english=True)
-            pub_date = timezone.now() + timezone.timedelta(
-                days=random.randint(-DAY_RANGE, DAY_RANGE),
-                hours=random.randint(-12, 12),
-                minutes=random.randint(-30, 30),
-            )
-            create_date = pub_date - timezone.timedelta(
-                days=random.randint(-CREATE_OFFSET, 0),
-                hours=random.randint(-12, 12),
-                minutes=random.randint(-30, 30),
-            )
+    with open(os.path.join(data_path, 'seed.pdf'), mode='rb') as dummy_pdf:
+        dummy_file = File(dummy_pdf, name='seed.pdf')
 
-            update_delta = timezone.timedelta(
-                days=random.randint(0, CREATE_OFFSET - 1),
-                hours=random.randint(-12, 12),
-                minutes=random.randint(-30, 30),
-            )
+        # Delete old data
+        Saksdokument.objects.all().delete()
 
-            Saksdokument.objects.create(
-                title_nb=name_no,
-                title_en=name_en,
-                publication_date=pub_date,
-                created_at=create_date,
-                updated_at=(create_date - update_delta) if random.randint(0, 2) == 0 else None,
-                category=random.choice(cats),
-                file=File(seed_file, name=f'seed_{i}.pdf')
-            )
-            yield int(i / count * 100), 'Creating documents'
+        # Faster in one transaction
+        with transaction.atomic():
 
-    yield 100, f'Created {count} documents.'
+            # Create documents
+            for i in range(COUNT):
+                name_no, name_en = words(2, include_english=True)
+                pub_date = timezone.now() + timezone.timedelta(
+                    days=random.randint(-DAY_RANGE, DAY_RANGE),
+                    hours=random.randint(-12, 12),
+                    minutes=random.randint(-30, 30),
+                )
+                create_date = pub_date - timezone.timedelta(
+                    days=random.randint(-CREATE_OFFSET, 0),
+                    hours=random.randint(-12, 12),
+                    minutes=random.randint(-30, 30),
+                )
+
+                update_delta = timezone.timedelta(
+                    days=random.randint(0, CREATE_OFFSET - 1),
+                    hours=random.randint(-12, 12),
+                    minutes=random.randint(-30, 30),
+                )
+
+                Saksdokument.objects.create(
+                    title_nb=name_no,
+                    title_en=name_en,
+                    publication_date=pub_date,
+                    created_at=create_date,
+                    updated_at=(create_date - update_delta) if random.randint(0, 2) == 0 else None,
+                    category=random.choice(cats),
+                    file=dummy_file
+                )
+                yield int(i / COUNT * 100), 'Creating documents'
+
+    yield 100, f'Created {COUNT} documents.'

--- a/backend/root/management/commands/seed_scripts/images.py
+++ b/backend/root/management/commands/seed_scripts/images.py
@@ -2,6 +2,7 @@ import os
 import random
 
 from django.core.files.images import ImageFile
+from django.db import transaction
 from django.db.models.deletion import ProtectedError
 
 from root.utils.samfundet_random import words
@@ -11,9 +12,15 @@ from samfundet.models.general import Image, Tag
 COUNT = 30
 
 
-def seed():
+def do_seed():
+
+    # Preload images first (faster than doing in seed loop)
     image_folder = os.path.join(os.path.dirname(__file__), 'seed_images')
     seed_images = os.listdir(image_folder)
+    image_files = []
+    for name in seed_images:
+        f = open(os.path.join(image_folder, name), mode='rb')
+        image_files.append(f)
 
     try:
         Image.objects.all().delete()
@@ -27,13 +34,23 @@ def seed():
         Tag.objects.create(name=words(1))
 
     for i in range(COUNT):
-        r_image_name = random.choice(seed_images)
-        with open(os.path.join(image_folder, r_image_name), mode='rb') as image_file:
-            random_image = ImageFile(image_file, name=r_image_name)
-            title = words(random.randint(1, 2))
-            image = Image.objects.create(title=title, image=random_image)
-            image.tags.set(random.choices(Tag.objects.all().values_list(flat=True, ), k=random.randint(1, 4)))
-            yield int(i / COUNT * 100), 'Creating images'
+        image_file = random.choice(image_files)
+        random_image = ImageFile(image_file, name=f'img_{i}')
+        title = words(random.randint(1, 2))
+        image = Image.objects.create(title=title, image=random_image)
+        image.tags.set(random.choices(Tag.objects.all().values_list(flat=True, ), k=random.randint(1, 4)))
+        yield int(i / COUNT * 100), 'Creating images'
+
+    # Remember to close files!
+    for image_file in image_files:
+        image_file.close()
 
     # Done!
     yield 100, f'Created {Image.objects.all().count()} images'
+
+
+def seed():
+    # Run in transaction for speed
+    with transaction.atomic():
+        for progress, msg in do_seed():
+            yield progress, msg


### PR DESCRIPTION
Speeds up seeding using transactions and smarter file loading.

For example, on my system:
- Events 10s -> 2.6s
- Documents 9.5s -> 4.6s
- Images 4.64s -> 1.2s
- ...

Or about 70% less time.

