### PR TITLE
add permissions for routes in frontend

### DIFF
--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes, Navigate, Outlet } from 'react-router-dom';
+import { Route, Routes, Navigate } from 'react-router-dom';
 import {
   AboutPage,
   AdminPage,
@@ -46,29 +46,39 @@ import { RecruitmentFormAdminPage } from './PagesAdmin/RecruitmentFormAdminPage'
 import { SaksdokumentAdminPage } from './PagesAdmin/SaksdokumentAdminPage';
 import { ROUTES } from './routes';
 import { PERM } from './permissions';
-import { usePermission } from '~/hooks';
 import { useAuthContext } from './AuthContext';
 import { UserDto } from './dto';
 import { hasPerm } from './utils';
+import { ElementType } from 'react';
 
-type ProtectedRouteProps = {
-  permissions?: string[] | null;
-  requiresAuth?: boolean;
-  redirectPath?: string;
-  Component: Element;
-};
+/**
+ * Router component, to be used inside element of a route, and page that is requested
+ * Allows for setting up routes that requires authentication, permissions, and staff
+ * @param {ElementType} Page - The page to be rendered
+ * @param {UserDto | undefined} user - the current user, undefined if not logged in
+ * @param {string[] | undefined} permissions - list of permissions needed to access page, undefined if not needed
+ * @param {string} redirectPath - redirect to specific page if wanted
+ * @param {boolean} requiresStaff: - if staff permissions are required for page
+ */
 
-const ProtectedRoute = ({
-  permissions = null,
-  redirectPath = ROUTES.frontend.home,
-  Component,
-}: ProtectedRouteProps) => {
-  const { user } = useAuthContext();
+const ProtectedRoute = (
+  Page: ElementType,
+  user?: UserDto | undefined,
+  permissions?: string[] | undefined,
+  redirectPath: string = ROUTES.frontend.home,
+  requiresStaff = true,
+) => {
+  // const { user } = useAuthContext(); // test for if this is the best level for fetching user
   console.log(user);
+
   if (!user) {
     // All Protected routes need a user, redirects to login
+    //
     //TODO improve to keep attempted route
     return <Navigate to={ROUTES.frontend.login} replace />;
+  }
+  if (requiresStaff && !user?.is_staff) {
+    return <Navigate to={redirectPath} replace />;
   }
   if (permissions) {
     for (const permission of permissions) {
@@ -82,14 +92,14 @@ const ProtectedRoute = ({
   }
   console.log(permissions);
   console.log(user.permissions);
-  return <Component />;
+  return <Page />;
 };
 
 export function AppRoutes() {
   // Must be called within <BrowserRouter> because it uses hook useLocation().
   useGoatCounter();
   const { user } = useAuthContext();
-  const isStaff = user?.is_staff;
+  //const isStaff = user?.is_staff;
 
   return (
     <Routes>
@@ -117,20 +127,20 @@ export function AppRoutes() {
       {/* 
             ADMIN ROUTES
       */}
-      <Route element={<ProtectedRoute Component={AdminLayout} />}>
-        <Route path={ROUTES.frontend.admin} element={<ProtectedRoute Component={AdminPage} />} />
+      <Route element={<ProtectedRoute Page={AdminLayout} />}>
+        <Route path={ROUTES.frontend.admin} element={<ProtectedRoute user={user} Page={AdminPage} />} />
         {/* Gangs */}
         <Route
           path={ROUTES.frontend.admin_gangs}
-          element={<ProtectedRoute permissions={[PERM.SAMFUNDET_VIEW_GANG]} Component={GangsAdminPage} />}
+          element={<ProtectedRoute permissions={[PERM.SAMFUNDET_VIEW_GANG]} user={user} Page={GangsAdminPage} />}
         />
         <Route
           path={ROUTES.frontend.admin_gangs_create}
-          element={<ProtectedRoute permissions={[PERM.SAMFUNDET_ADD_GANG]} Component={GangsFormAdminPage} />}
+          element={<ProtectedRoute permissions={[PERM.SAMFUNDET_ADD_GANG]} user={user} Page={GangsFormAdminPage} />}
         />
         <Route
           path={ROUTES.frontend.admin_gangs_edit}
-          element={<ProtectedRoute permissions={[PERM.SAMFUNDET_ADD_GANG]} Component={GangsFormAdminPage} />}
+          element={<ProtectedRoute permissions={[PERM.SAMFUNDET_ADD_GANG]} user={user} Page={GangsFormAdminPage} />}
         />
         {/* Events */}
         <Route path={ROUTES.frontend.admin_events} element={<EventsAdminPage />} />

--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -47,6 +47,7 @@ import { SaksdokumentAdminPage } from './PagesAdmin/SaksdokumentAdminPage';
 import { ROUTES } from './routes';
 import { PERM } from './permissions';
 import { ProtectedRoute } from './Components';
+import { SAMFUNDET_CHANGE_CLOSEDPERIOD } from './permissions/permissions';
 
 export function AppRoutes() {
   // Must be called within <BrowserRouter> because it uses hook useLocation().
@@ -105,45 +106,101 @@ export function AppRoutes() {
           path={ROUTES.frontend.admin_events_create}
           element={<ProtectedRoute perms={[PERM.SAMFUNDET_ADD_EVENT]} Page={EventCreatorAdminPage} />}
         />
-        <Route path={ROUTES.frontend.admin_events_edit} element={<ProtectedRoute perms={[PERM.SAMFUNDET_CHANGE_EVENT]} Page={EventCreatorAdminPage} />} />
+        <Route
+          path={ROUTES.frontend.admin_events_edit}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_CHANGE_EVENT]} Page={EventCreatorAdminPage} />}
+        />
         {/* 
           Info pages 
           NOTE: edit/create uses custom views
         */}
-        <Route path={ROUTES.frontend.admin_information} element={<InformationAdminPage />} />
-        {/* Opening hours */}
-        <Route path={ROUTES.frontend.admin_opening_hours} element={<OpeningHoursAdminPage />} />
+        <Route
+          path={ROUTES.frontend.admin_information}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_VIEW_INFORMATIONPAGE]} Page={InformationAdminPage} />}
+        />
+        {/* Opening hours, TODO ADD OPENING HOURS PERMISSIONS*/}
+        <Route
+          path={ROUTES.frontend.admin_opening_hours}
+          element={<ProtectedRoute perms={[]} Page={OpeningHoursAdminPage} />}
+        />
         {/* Closed period */}
-        <Route path={ROUTES.frontend.admin_closed} element={<ClosedPeriodAdminPage />} />
-        <Route path={ROUTES.frontend.admin_closed_create} element={<ClosedPeriodFormAdminPage />} />
-        <Route path={ROUTES.frontend.admin_closed_edit} element={<ClosedPeriodFormAdminPage />} />
+        <Route
+          path={ROUTES.frontend.admin_closed}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_VIEW_CLOSEDPERIOD]} Page={ClosedPeriodAdminPage} />}
+        />
+        <Route
+          path={ROUTES.frontend.admin_closed_create}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_ADD_CLOSEDPERIOD]} Page={ClosedPeriodFormAdminPage} />}
+        />
+        <Route
+          path={ROUTES.frontend.admin_closed_edit}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_CHANGE_CLOSEDPERIOD]} Page={ClosedPeriodFormAdminPage} />}
+        />
         {/* Images */}
-        <Route path={ROUTES.frontend.admin_images} element={<ImageAdminPage />} />
-        <Route path={ROUTES.frontend.admin_images_create} element={<ImageFormAdminPage />} />
+        <Route
+          path={ROUTES.frontend.admin_images}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_VIEW_IMAGE]} Page={ImageAdminPage} />}
+        />
+        <Route
+          path={ROUTES.frontend.admin_images_create}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_ADD_IMAGE]} Page={ImageFormAdminPage} />}
+        />
         {/* Saksdokumenter */}
-        <Route path={ROUTES.frontend.admin_saksdokumenter} element={<SaksdokumentAdminPage />} />
-        <Route path={ROUTES.frontend.admin_saksdokumenter_create} element={<SaksdokumentFormAdminPage />} />
-        <Route path={ROUTES.frontend.admin_saksdokumenter_edit} element={<SaksdokumentFormAdminPage />} />
+        <Route
+          path={ROUTES.frontend.admin_saksdokumenter}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_VIEW_SAKSDOKUMENT]} Page={SaksdokumentAdminPage} />}
+        />
+        <Route
+          path={ROUTES.frontend.admin_saksdokumenter_create}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_ADD_SAKSDOKUMENT]} Page={SaksdokumentFormAdminPage} />}
+        />
+        <Route
+          path={ROUTES.frontend.admin_saksdokumenter_edit}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_CHANGE_SAKSDOKUMENT]} Page={SaksdokumentFormAdminPage} />}
+        />
         {/* Recruitment */}
-        <Route path={ROUTES.frontend.admin_recruitment} element={<RecruitmentAdminPage />} />
-        <Route path={ROUTES.frontend.admin_recruitment_create} element={<RecruitmentFormAdminPage />} />
-        <Route path={ROUTES.frontend.admin_recruitment_edit} element={<RecruitmentFormAdminPage />} />
-        <Route path={ROUTES.frontend.admin_recruitment_gang_overview} element={<RecruitmentGangOverviewPage />} />
-        <Route path={ROUTES.frontend.admin_recruitment_gang_position_overview} element={<RecruitmentGangAdminPage />} />
+        <Route
+          path={ROUTES.frontend.admin_recruitment}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_VIEW_RECRUITMENT]} Page={RecruitmentAdminPage} />}
+        />
+        <Route
+          path={ROUTES.frontend.admin_recruitment_create}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_ADD_RECRUITMENT]} Page={RecruitmentFormAdminPage} />}
+        />
+        <Route
+          path={ROUTES.frontend.admin_recruitment_edit}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_CHANGE_RECRUITMENT]} Page={RecruitmentFormAdminPage} />}
+        />
+        {/* TODO ADD PERMISSIONS */}
+        <Route
+          path={ROUTES.frontend.admin_recruitment_gang_overview}
+          element={<ProtectedRoute perms={[]} Page={RecruitmentGangOverviewPage} />}
+        />
+        <Route
+          path={ROUTES.frontend.admin_recruitment_gang_position_overview}
+          element={<ProtectedRoute perms={[]} Page={RecruitmentGangAdminPage} />}
+        />
+
         <Route
           path={ROUTES.frontend.admin_recruitment_gang_position_create}
-          element={<RecruitmentPositionFormAdminPage />}
+          element={<ProtectedRoute perms={[]} Page={RecruitmentPositionFormAdminPage} />}
         />
         <Route
           path={ROUTES.frontend.admin_recruitment_gang_position_edit}
-          element={<RecruitmentPositionFormAdminPage />}
+          element={<ProtectedRoute perms={[]} Page={RecruitmentPositionFormAdminPage} />}
         />
         {/* 
         Info pages
         Custom layout for edit/create
       */}
-        <Route path={ROUTES.frontend.admin_information_create} element={<InformationFormAdminPage />} />
-        <Route path={ROUTES.frontend.admin_information_edit} element={<InformationFormAdminPage />} />
+        <Route
+          path={ROUTES.frontend.admin_information_create}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_ADD_INFORMATIONPAGE]} Page={InformationFormAdminPage} />}
+        />
+        <Route
+          path={ROUTES.frontend.admin_information_edit}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_CHANGE_INFORMATIONPAGE]} Page={InformationFormAdminPage} />}
+        />
       </Route>
       {/* 
             SULTEN ROUTES

--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -94,15 +94,18 @@ export function AppRoutes() {
         />
         <Route
           path={ROUTES.frontend.admin_gangs_edit}
-          element={<ProtectedRoute perms={[PERM.SAMFUNDET_ADD_GANG]} Page={GangsFormAdminPage} />}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_CHANGE_GANG]} Page={GangsFormAdminPage} />}
         />
         {/* Events */}
         <Route
           path={ROUTES.frontend.admin_events}
           element={<ProtectedRoute perms={[PERM.SAMFUNDET_VIEW_EVENT]} Page={EventsAdminPage} />}
         />
-        <Route path={ROUTES.frontend.admin_events_create} element={<EventCreatorAdminPage />} />
-        <Route path={ROUTES.frontend.admin_events_edit} element={<EventCreatorAdminPage />} />
+        <Route
+          path={ROUTES.frontend.admin_events_create}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_ADD_EVENT]} Page={EventCreatorAdminPage} />}
+        />
+        <Route path={ROUTES.frontend.admin_events_edit} element={<ProtectedRoute perms={[PERM.SAMFUNDET_CHANGE_EVENT]} Page={EventCreatorAdminPage} />} />
         {/* 
           Info pages 
           NOTE: edit/create uses custom views

--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes, Navigate } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import {
   AboutPage,
   AdminPage,
@@ -46,60 +46,11 @@ import { RecruitmentFormAdminPage } from './PagesAdmin/RecruitmentFormAdminPage'
 import { SaksdokumentAdminPage } from './PagesAdmin/SaksdokumentAdminPage';
 import { ROUTES } from './routes';
 import { PERM } from './permissions';
-import { useAuthContext } from './AuthContext';
-import { UserDto } from './dto';
-import { hasPerm } from './utils';
-import { ElementType } from 'react';
-
-/**
- * Router component, to be used inside element of a route, and page that is requested
- * Allows for setting up routes that requires authentication, permissions, and staff
- * @param {ElementType} Page - The page to be rendered
- * @param {UserDto | undefined} user - the current user, undefined if not logged in
- * @param {string[] | undefined} permissions - list of permissions needed to access page, undefined if not needed
- * @param {string} redirectPath - redirect to specific page if wanted
- * @param {boolean} requiresStaff: - if staff permissions are required for page
- */
-
-const ProtectedRoute = (
-  Page: ElementType,
-  user?: UserDto | undefined,
-  permissions?: string[] | undefined,
-  redirectPath: string = ROUTES.frontend.home,
-  requiresStaff = true,
-) => {
-  // const { user } = useAuthContext(); // test for if this is the best level for fetching user
-  console.log(user);
-
-  if (!user) {
-    // All Protected routes need a user, redirects to login
-    //
-    //TODO improve to keep attempted route
-    return <Navigate to={ROUTES.frontend.login} replace />;
-  }
-  if (requiresStaff && !user?.is_staff) {
-    return <Navigate to={redirectPath} replace />;
-  }
-  if (permissions) {
-    for (const permission of permissions) {
-      console.log('perm', permission);
-      console.log(permissions);
-      console.log(hasPerm({ permission: permission, user: user }));
-      if (!hasPerm({ permission: permission, user: user })) {
-        return <Navigate to={redirectPath} replace />;
-      }
-    }
-  }
-  console.log(permissions);
-  console.log(user.permissions);
-  return <Page />;
-};
+import { ProtectedRoute } from './Components';
 
 export function AppRoutes() {
   // Must be called within <BrowserRouter> because it uses hook useLocation().
   useGoatCounter();
-  const { user } = useAuthContext();
-  //const isStaff = user?.is_staff;
 
   return (
     <Routes>
@@ -127,23 +78,29 @@ export function AppRoutes() {
       {/* 
             ADMIN ROUTES
       */}
-      <Route element={<ProtectedRoute Page={AdminLayout} />}>
-        <Route path={ROUTES.frontend.admin} element={<ProtectedRoute user={user} Page={AdminPage} />} />
+      <Route element={<ProtectedRoute perms={[PERM.SAMFUNDET_VIEW_GANG]} Page={AdminLayout} />}>
+        <Route
+          path={ROUTES.frontend.admin}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_VIEW_GANG]} Page={AdminPage} />}
+        />
         {/* Gangs */}
         <Route
           path={ROUTES.frontend.admin_gangs}
-          element={<ProtectedRoute permissions={[PERM.SAMFUNDET_VIEW_GANG]} user={user} Page={GangsAdminPage} />}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_VIEW_GANG]} Page={GangsAdminPage} />}
         />
         <Route
           path={ROUTES.frontend.admin_gangs_create}
-          element={<ProtectedRoute permissions={[PERM.SAMFUNDET_ADD_GANG]} user={user} Page={GangsFormAdminPage} />}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_ADD_GANG]} Page={GangsFormAdminPage} />}
         />
         <Route
           path={ROUTES.frontend.admin_gangs_edit}
-          element={<ProtectedRoute permissions={[PERM.SAMFUNDET_ADD_GANG]} user={user} Page={GangsFormAdminPage} />}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_ADD_GANG]} Page={GangsFormAdminPage} />}
         />
         {/* Events */}
-        <Route path={ROUTES.frontend.admin_events} element={<EventsAdminPage />} />
+        <Route
+          path={ROUTES.frontend.admin_events}
+          element={<ProtectedRoute perms={[PERM.SAMFUNDET_VIEW_EVENT]} Page={EventsAdminPage} />}
+        />
         <Route path={ROUTES.frontend.admin_events_create} element={<EventCreatorAdminPage />} />
         <Route path={ROUTES.frontend.admin_events_edit} element={<EventCreatorAdminPage />} />
         {/* 

--- a/frontend/src/Components/ProtectedRoute/ProtectedRoute.tsx
+++ b/frontend/src/Components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuthContext } from '~/AuthContext';
 import { hasPerm } from '~/utils';
 import { ROUTES } from '~/routes';
@@ -28,10 +28,11 @@ export function ProtectedRoute({
   redirectPath = ROUTES.frontend.home, // TODO ADD 403?
   requiresStaff = false,
 }: ProtectedRouteProps) {
+  const location = useLocation();
   const { user } = useAuthContext(); //TODO ADD LOADER FOR AUTHCONTEXT
 
   if (!user) {
-    return <Navigate to={ROUTES.frontend.login} replace />;
+    return <Navigate to={ROUTES.frontend.login} replace state={{ from: location }} />;
   }
   if (requiresStaff && !user?.is_staff) {
     return <Navigate to={redirectPath} replace />;

--- a/frontend/src/Components/ProtectedRoute/ProtectedRoute.tsx
+++ b/frontend/src/Components/ProtectedRoute/ProtectedRoute.tsx
@@ -35,7 +35,7 @@ export function ProtectedRoute({
     return <Navigate to={ROUTES.frontend.login} replace state={{ from: location }} />;
   }
   if (requiresStaff && !user?.is_staff) {
-    return <Navigate to={redirectPath} replace />;
+    return <Navigate to={redirectPath} replace />; // Replace replace current navigation head instead of pushing it
   }
   if (perms) {
     for (const permission of perms) {

--- a/frontend/src/Components/ProtectedRoute/index.ts
+++ b/frontend/src/Components/ProtectedRoute/index.ts
@@ -1,0 +1,1 @@
+export { ProtectedRoute } from './ProtectedRoute';

--- a/frontend/src/Components/index.ts
+++ b/frontend/src/Components/index.ts
@@ -49,3 +49,4 @@ export { TimeDuration } from './TimeDuration';
 export { ToggleSwitch } from './ToggleSwitch';
 export { Video } from './Video';
 export { Footer } from './Footer';
+export { ProtectedRoute } from './ProtectedRoute';

--- a/frontend/src/Pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/Pages/LoginPage/LoginPage.tsx
@@ -1,12 +1,13 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useAuthContext } from '~/AuthContext';
 import { Alert, Page } from '~/Components';
 import { SamfForm } from '~/Forms/SamfForm';
 import { SamfFormField } from '~/Forms/SamfFormField';
 import { getUser, login } from '~/api';
+
 import { STATUS } from '~/http_status_codes';
 import { KEY } from '~/i18n/constants';
 import { ROUTES } from '~/routes';
@@ -15,8 +16,14 @@ import styles from './LoginPage.module.scss';
 export function LoginPage() {
   const { t } = useTranslation();
   const [loginFailed, setLoginFailed] = useState(false);
-  const { setUser } = useAuthContext();
+  const location = useLocation();
+  const { from } = location.state || {};
+  const { user, setUser } = useAuthContext();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (user) navigate(typeof from === 'undefined' ? ROUTES.frontend.home : from.pathname);
+  }, [user]);
 
   function handleLogin(formData: Record<string, string>) {
     login(formData['name'], formData['password'])
@@ -26,7 +33,7 @@ export function LoginPage() {
             setUser(user);
           });
 
-          navigate(ROUTES.frontend.home);
+          navigate(typeof from === 'undefined' ? ROUTES.frontend.home : from.pathname);
         } else {
           setLoginFailed(true);
         }


### PR DESCRIPTION
Added a ProtectedRoute, which takes in permissions, and returns the correct route if correct, if false it redirects to home or future 403 page.

Will add for rest of the admin routes, now only tested on gangs, at it seems to work

Still has a bug where it does not accept manual routes, because of useAuthContext takes time to load. 
Should find a fix in routes for loading User