### PR TITLE
Reduce button gap and remove unnecessary button content wrappers

### DIFF
--- a/frontend/src/Components/Button/Button.module.scss
+++ b/frontend/src/Components/Button/Button.module.scss
@@ -5,7 +5,7 @@
 
 .button {
   @include flex-row;
-  gap: 1em;
+  gap: 0.5rem;
   border: none;
   cursor: pointer;
   border-radius: 0.25em;

--- a/frontend/src/Components/ContentCard/ContentCard.module.scss
+++ b/frontend/src/Components/ContentCard/ContentCard.module.scss
@@ -116,12 +116,6 @@ $background-dark: #2e2b2b;
   }
 }
 
-.button_content {
-  display: flex;
-  align-items: center;
-  gap: 0.5em;
-}
-
 .icon {
   display: inline-block;
   transition: 0.4s;

--- a/frontend/src/Components/ContentCard/ContentCard.tsx
+++ b/frontend/src/Components/ContentCard/ContentCard.tsx
@@ -59,10 +59,8 @@ export function ContentCard({
           {buttonText && (
             <div className={styles.info_bottom_row}>
               <Button className={styles.btn} rounded={true} theme="black" onClick={() => followLink(url ?? '#')}>
-                <div className={styles.button_content}>
-                  <span>{buttonText}</span>
-                  <Icon className={styles.icon} icon="mdi:arrow-right" width={18} />
-                </div>
+                {buttonText}
+                <Icon className={styles.icon} icon="mdi:arrow-right" width={18} />
               </Button>
             </div>
           )}

--- a/frontend/src/Pages/EventsPage/components/EventsList/EventsList.tsx
+++ b/frontend/src/Pages/EventsPage/components/EventsList/EventsList.tsx
@@ -97,10 +97,8 @@ export function EventsList({ events }: EventsListProps) {
   function getButton(title: string, icon: string, func: () => void, chosen: boolean) {
     return (
       <Button rounded={true} onClick={func} theme={chosen ? 'blue' : 'secondary'}>
-        <span style={{ display: 'flex', gap: '1em' }}>
-          {title}
-          <Icon icon={icon} />
-        </span>
+        {title}
+        <Icon icon={icon} />
       </Button>
     );
   }


### PR DESCRIPTION
Applies to using icons inside buttons. Makes the distance a bit smaller and more natural-looking and removes some unnecessary wrappers