### PR TITLE
Add info section to Splash component

### DIFF
--- a/frontend/src/Components/Button/Button.module.scss
+++ b/frontend/src/Components/Button/Button.module.scss
@@ -13,6 +13,11 @@
   box-shadow: 1px 1px 10px 3px rgba(0, 0, 0, 0.05);
   justify-content: center;
 
+  // Remove underline when button is a link
+  &, &:hover {
+    text-decoration: none;
+  }
+
   &:disabled {
     opacity: 0.5;
     background-color: $grey-3;

--- a/frontend/src/Components/Button/Button.tsx
+++ b/frontend/src/Components/Button/Button.tsx
@@ -1,6 +1,7 @@
 import { default as classNames, default as classnames } from 'classnames';
 import { ButtonType, Children } from '~/types';
 import styles from './Button.module.scss';
+import { Link } from 'react-router-dom';
 
 type ButtonTheme =
   | 'basic'
@@ -21,6 +22,7 @@ type ButtonProps = {
   display?: ButtonDisplay;
   type?: ButtonType;
   rounded?: boolean;
+  link?: string;
   className?: string;
   disabled?: boolean;
   children?: Children;
@@ -52,6 +54,7 @@ export function Button({
   theme = 'basic',
   display = 'basic',
   rounded = false,
+  link,
   onClick,
   disabled,
   className,
@@ -77,9 +80,15 @@ export function Button({
 
   return (
     <>
-      <button name={name} onClick={handleOnClick} disabled={disabled} className={classNames}>
-        {children}
-      </button>
+      {link ? (
+        <Link to={link} onClick={handleOnClick} className={classNames}>
+          {children}
+        </Link>
+      ) : (
+        <button name={name} onClick={handleOnClick} disabled={disabled} className={classNames}>
+          {children}
+        </button>
+      )}
     </>
   );
 }

--- a/frontend/src/Pages/HomePage/HomePage.module.scss
+++ b/frontend/src/Pages/HomePage/HomePage.module.scss
@@ -89,6 +89,50 @@
   }
 }
 
+.splash_info_wrapper {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  z-index: 1;
+  height: 12rem;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.3) 0%, transparent);
+  padding-bottom: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: 0.5rem;
+
+  @include for-mobile-down {
+    display: none;
+  }
+}
+
+.splash_info {
+  width: 1500px;
+  margin: 0 auto;
+  max-width: calc(100vw - 5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.splash_buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.ticket_button {
+  font-weight: 500;
+}
+
+.splash_description {
+  color: $white;
+  text-shadow: 1px 1px 8px rgba(0, 0, 0, 0.5);
+  width: 650px;
+  max-width: 100%;
+}
+
 .content {
   position: relative;
   top: -$navbar-height;

--- a/frontend/src/Pages/HomePage/HomePage.tsx
+++ b/frontend/src/Pages/HomePage/HomePage.tsx
@@ -48,7 +48,7 @@ export function HomePage() {
 
   return (
     <div>
-      <Splash events={homePage?.splash} />
+      <Splash events={homePage?.splash} showInfo={true} />
       <div className={styles.content}>
         {/*<SplashHeaderBox />*/}
         {isLoading && skeleton}

--- a/frontend/src/Pages/HomePage/components/Splash/Splash.tsx
+++ b/frontend/src/Pages/HomePage/components/Splash/Splash.tsx
@@ -32,15 +32,16 @@ export function Splash({ events, showInfo }: SplashProps) {
 
   const description = events ? dbT(events[index], 'description_short') : '';
 
-  const ticketButton =
-    events && PAID_TICKET_TYPES.includes(events[index].ticket_type) ? (
-      <Button theme={'samf'} className={styles.ticket_button}>
-        <Icon icon="ph:ticket-bold" />
-        {`${t(KEY.common_buy)} ${t(KEY.common_ticket_type)}`}
-      </Button>
-    ) : (
-      <></>
-    );
+  const isPaid = events && PAID_TICKET_TYPES.includes(events[index].ticket_type);
+
+  const ticketButton = isPaid ? (
+    <Button theme={'samf'} className={styles.ticket_button}>
+      <Icon icon="ph:ticket-bold" />
+      {`${t(KEY.common_buy)} ${t(KEY.common_ticket_type)}`}
+    </Button>
+  ) : (
+    <></>
+  );
 
   const infoButton = events && (
     <Button

--- a/frontend/src/Pages/HomePage/components/Splash/Splash.tsx
+++ b/frontend/src/Pages/HomePage/components/Splash/Splash.tsx
@@ -3,15 +3,25 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { BACKEND_DOMAIN } from '~/constants';
 import { EventDto } from '~/dto';
 import styles from '../../HomePage.module.scss';
+import { dbT } from '~/utils';
+import { Button } from '~/Components';
+import { useTranslation } from 'react-i18next';
+import { KEY } from '~/i18n/constants';
+import { Icon } from '@iconify/react';
+import { PAID_TICKET_TYPES } from '~/types';
+import { ROUTES } from '~/routes';
+import { reverse } from '~/named-urls';
 
 type SplashProps = {
   events?: EventDto[];
+  showInfo?: boolean;
 };
 
 // Milliseconds between each slide
 const SLIDE_FREQUENCY = 5_000;
 
-export function Splash({ events }: SplashProps) {
+export function Splash({ events, showInfo }: SplashProps) {
+  const { t } = useTranslation();
   const [isAnimating, setIsAnimating] = useState(false);
 
   const [index, setIndex] = useState<number>(0);
@@ -19,6 +29,30 @@ export function Splash({ events }: SplashProps) {
 
   const imageUrl = events ? BACKEND_DOMAIN + events[index].image_url : '';
   const nextImageUrl = events ? BACKEND_DOMAIN + events[nextIndex].image_url : '';
+
+  const description = events ? dbT(events[index], 'description_short') : '';
+
+  const ticketButton =
+    events && PAID_TICKET_TYPES.includes(events[index].ticket_type) ? (
+      <Button theme={'samf'} className={styles.ticket_button}>
+        <Icon icon="ph:ticket-bold" />
+        {`${t(KEY.common_buy)} ${t(KEY.common_ticket_type)}`}
+      </Button>
+    ) : (
+      <></>
+    );
+
+  const infoButton = events && (
+    <Button
+      link={reverse({
+        pattern: ROUTES.frontend.event,
+        urlParams: { id: events[index].id },
+      })}
+    >
+      <Icon icon="ic:outline-info" />
+      <span>{t(KEY.common_more_info)}</span>
+    </Button>
+  );
 
   const slideTimeout = useRef<NodeJS.Timeout>();
 
@@ -48,6 +82,17 @@ export function Splash({ events }: SplashProps) {
 
   return (
     <div className={styles.splash_container}>
+      {showInfo && (
+        <div className={styles.splash_info_wrapper}>
+          <div className={styles.splash_info}>
+            <span className={styles.splash_description}>{description}</span>
+            <div className={styles.splash_buttons}>
+              {ticketButton}
+              {infoButton}
+            </div>
+          </div>
+        </div>
+      )}
       <img
         src={imageUrl}
         className={classNames({ [styles.splash]: true, [styles.splash_slide_out]: isAnimating })}

--- a/frontend/src/PagesAdmin/EventCreatorAdminPage/components/PaymentForm.tsx
+++ b/frontend/src/PagesAdmin/EventCreatorAdminPage/components/PaymentForm.tsx
@@ -3,7 +3,7 @@ import { DropDownOption } from '~/Components/Dropdown/Dropdown';
 import { SamfFormField } from '~/Forms/SamfFormField';
 import { EventCustomTicketDto, EventDto } from '~/dto';
 import { KEY } from '~/i18n/constants';
-import { ALL_TICKET_TYPES, EventTicketType } from '~/types';
+import { ALL_TICKET_TYPES, EventTicketTypeValue } from '~/types';
 import { getTicketTypeKey } from '~/utils';
 import { CustomTicketEditor } from './CustomTicketEditor';
 
@@ -18,7 +18,7 @@ export function PaymentForm({ event, onChange }: PaymentFormProps) {
   const { t } = useTranslation();
 
   // Dropdown for price group
-  const ticketTypeOptions: DropDownOption<EventTicketType>[] = ALL_TICKET_TYPES.map((ticketType) => {
+  const ticketTypeOptions: DropDownOption<EventTicketTypeValue>[] = ALL_TICKET_TYPES.map((ticketType) => {
     return {
       value: ticketType,
       label: t(getTicketTypeKey(ticketType)) ?? '',

--- a/frontend/src/dto.ts
+++ b/frontend/src/dto.ts
@@ -1,5 +1,5 @@
 import { ThemeValue } from '~/constants';
-import { EventAgeRestriction, EventStatus, EventTicketType, HomePageElementVariation } from './types';
+import { EventAgeRestriction, EventStatus, EventTicketTypeValue, HomePageElementVariation } from './types';
 
 export type UserDto = {
   id: number;
@@ -118,7 +118,7 @@ export type EventDto = {
   publish_dt: string;
 
   // Ticket type for event (billig, free, custom, registration etc.)
-  ticket_type: EventTicketType;
+  ticket_type: EventTicketTypeValue;
 
   // Custom tickets (only relevant for custom price group events)
   custom_tickets: EventCustomTicketDto[];

--- a/frontend/src/i18n/constants.ts
+++ b/frontend/src/i18n/constants.ts
@@ -106,6 +106,7 @@ export const KEY = {
   common_festivals: 'common_festivals',
   common_sponsor: 'common_sponsors',
   common_here: 'common_here',
+  common_more_info: 'common_more_info',
 
   // Price groups
   common_ticket_type_billig: 'common_ticket_type_billig',

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -96,6 +96,7 @@ export const nb: Record<KeyValues, string> = {
   [KEY.common_sponsor]: 'Sponsorer',
   [KEY.common_festivals]: 'Festivaler',
   [KEY.common_here]: 'her',
+  [KEY.common_more_info]: 'Mer info',
   // Price groups
   [KEY.common_ticket_type]: 'Billett',
   [KEY.common_ticket_type_free]: 'Gratis',
@@ -285,6 +286,7 @@ export const en: Record<KeyValues, string> = {
   [KEY.common_sponsor]: 'Sponsors',
   [KEY.common_festivals]: 'Festivals',
   [KEY.common_here]: 'here',
+  [KEY.common_more_info]: 'More info',
 
   // Price groups
   [KEY.common_ticket_type_billig]: 'Paid',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -84,9 +84,28 @@ export const ALL_DAYS: Day[] = ['monday', 'tuesday', 'wednesday', 'thursday', 'f
 export const WEEK_DAYS: Day[] = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'];
 
 /** Event types */
-export type EventTicketType = 'free' | 'included' | 'billig' | 'registration' | 'custom';
 export type EventAgeRestriction = 'none' | 'eighteen' | 'twenty' | 'mixed';
 export type EventStatus = 'active' | 'cancelled' | 'archived' | 'deleted';
 
-export const ALL_TICKET_TYPES: EventTicketType[] = ['free', 'included', 'billig', 'registration', 'custom'];
-export const PAID_TICKET_TYPES: EventTicketType[] = ['billig', 'custom', 'registration'];
+export const EventTicketType = {
+  FREE: 'free',
+  INCLUDED: 'included',
+  BILLIG: 'billig',
+  REGISTRATION: 'registration',
+  CUSTOM: 'custom',
+} as const;
+
+export type EventTicketTypeValue = typeof EventTicketType[keyof typeof EventTicketType];
+
+export const ALL_TICKET_TYPES: EventTicketTypeValue[] = [
+  EventTicketType.FREE,
+  EventTicketType.INCLUDED,
+  EventTicketType.BILLIG,
+  EventTicketType.REGISTRATION,
+  EventTicketType.CUSTOM,
+];
+export const PAID_TICKET_TYPES: EventTicketTypeValue[] = [
+  EventTicketType.BILLIG,
+  EventTicketType.REGISTRATION,
+  EventTicketType.CUSTOM,
+];

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -89,3 +89,4 @@ export type EventAgeRestriction = 'none' | 'eighteen' | 'twenty' | 'mixed';
 export type EventStatus = 'active' | 'cancelled' | 'archived' | 'deleted';
 
 export const ALL_TICKET_TYPES: EventTicketType[] = ['free', 'included', 'billig', 'registration', 'custom'];
+export const PAID_TICKET_TYPES: EventTicketType[] = ['billig', 'custom', 'registration'];

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -3,7 +3,7 @@ import { CSSProperties } from 'react';
 import { CURSOR_TRAIL_CLASS, THEME_KEY, ThemeValue } from '~/constants';
 import { UserDto } from '~/dto';
 import { KEY, KeyValues } from './i18n/constants';
-import { Day, EventTicketType } from './types';
+import { Day, EventTicketTypeValue, EventTicketType } from './types';
 
 export type hasPerm = {
   user: UserDto | undefined;
@@ -138,17 +138,17 @@ export function getDayKey(day: Day): KeyValues {
 /**
  * Gets the translation key for a given price group
  */
-export function getTicketTypeKey(ticketType: EventTicketType): KeyValues {
+export function getTicketTypeKey(ticketType: EventTicketTypeValue): KeyValues {
   switch (ticketType) {
-    case 'free':
+    case EventTicketType.FREE:
       return KEY.common_ticket_type_free;
-    case 'included':
+    case EventTicketType.INCLUDED:
       return KEY.common_ticket_type_included;
-    case 'billig':
+    case EventTicketType.BILLIG:
       return KEY.common_ticket_type_billig;
-    case 'custom':
+    case EventTicketType.CUSTOM:
       return KEY.common_ticket_type_custom;
-    case 'registration':
+    case EventTicketType.REGISTRATION:
       return KEY.common_ticket_type_registration;
   }
 }


### PR DESCRIPTION
Currently you can’t interact with the splash component in any way, which may be annoying for users. This PR adds the event's short description, a "More info" button, and if the event is paid: a "Buy ticket" button. The "Buy ticket" button does nothing currently.

I think another solution is required for mobile, so currently the info section is hidden for mobile. Perhaps just making the splash image clickable for mobile?

Screenshot:
![screenshot](https://github.com/Samfundet/Samfundet4/assets/16273164/9e30314a-0930-44e8-b25e-613da2937908)


# Notable changes

- Add `PAID_TICKET_TYPES` constant
- Add `link` property to Button component. If non-empty, will switch out `button` element with Link component.