### PR TITLE
Fix ThemeSwitch button

### DIFF
--- a/frontend/src/Components/Button/Button.tsx
+++ b/frontend/src/Components/Button/Button.tsx
@@ -25,6 +25,7 @@ type ButtonProps = {
   link?: string;
   className?: string;
   disabled?: boolean;
+  tabIndex?: number;
   children?: Children;
   preventDefault?: boolean;
   onClick?: () => void;
@@ -60,6 +61,7 @@ export function Button({
   className,
   children,
   preventDefault = false,
+  ...props
 }: ButtonProps) {
   const isPure = theme === 'pure';
 
@@ -81,11 +83,11 @@ export function Button({
   return (
     <>
       {link ? (
-        <Link to={link} onClick={handleOnClick} className={classNames}>
+        <Link to={link} onClick={handleOnClick} className={classNames} {...props}>
           {children}
         </Link>
       ) : (
-        <button name={name} onClick={handleOnClick} disabled={disabled} className={classNames}>
+        <button name={name} onClick={handleOnClick} disabled={disabled} className={classNames} {...props}>
           {children}
         </button>
       )}

--- a/frontend/src/Components/ThemeSwitch/ThemeSwitch.module.scss
+++ b/frontend/src/Components/ThemeSwitch/ThemeSwitch.module.scss
@@ -1,15 +1,9 @@
 @import 'src/constants';
 
-.button {
+.wrapper {
   cursor: pointer;
-  transition: 0.1s;
-  color: white;
-  background: none;
-  border: none;
-  &:hover {
-    .icon {
-      transform: scale(1.1);
-      transform-origin: 50% 50%;
-    }
-  }
+}
+
+.icon:hover {
+  scale: 1.1;
 }

--- a/frontend/src/Components/ThemeSwitch/ThemeSwitch.tsx
+++ b/frontend/src/Components/ThemeSwitch/ThemeSwitch.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { useGlobalContext } from '~/GlobalContextProvider';
 import { useIsDarkTheme } from '~/hooks';
 import styles from './ThemeSwitch.module.scss';
+import { Button } from '~/Components';
 
 type ThemeSwitchProps = {
   className?: string;
@@ -16,8 +17,8 @@ export function ThemeSwitch({ className }: ThemeSwitchProps) {
   const offIcon = <Icon icon="ph:sun-thin" inline={true} width={24} className={styles.icon} />;
 
   return (
-    <button tabIndex={0} onClick={switchTheme} className={classnames(styles.button, className)}>
+    <Button tabIndex={0} onClick={switchTheme} theme="pure" className={classnames(styles.wrapper, className)}>
       {isDarkTheme ? onIcon : offIcon}
-    </button>
+    </Button>
   );
 }


### PR DESCRIPTION
Current ThemeSwitch button icon has `color: white`, making it invisible with the white navbar

Notable changes:

- Use Button component in ThemeSwitch
- Added tabIndex property to Button component