### PR TITLE
ToggleSwitch style improvements

### DIFF
--- a/frontend/src/Components/ToggleSwitch/ToggleSwitch.module.scss
+++ b/frontend/src/Components/ToggleSwitch/ToggleSwitch.module.scss
@@ -8,13 +8,20 @@
   box-sizing: border-box;
 }
 
-$switch-width: 60px;
-$switch-height: 30px;
+$switch-width: 2.5rem;
+$switch-height: 1.5rem;
+
 $switch-color: $grey-2;
 $switch-color-checked: $red-samf;
+$focus-box-shadow: 0 0 0 2px rgba($switch-color-checked, 0.5);
 $toggle-transition: 0.2s ease;
-$ball-size: 25px;
 $ball-color: $white;
+$ball-size: calc($switch-height - (0.125rem * 2));
+$track-padding: calc(($switch-height - $ball-size) / 2);
+
+.label {
+  margin-bottom: 0; // TODO: Can be removed once label's margin-bottom is removed from global.scss
+}
 
 .toggle_switch {
   opacity: 0;
@@ -22,23 +29,14 @@ $ball-color: $white;
   cursor: pointer;
 }
 
-.label {
+.track {
   cursor: pointer;
   width: $switch-width;
   height: $switch-height;
-  display: flex;
   background-color: $switch-color;
-  border-radius: 50px;
-  align-items: center;
-  justify-content: space-between;
-  padding: 5px;
+  border-radius: $switch-height;
   position: relative;
   transition: background-color $toggle-transition;
-}
-
-// Styling on label when toggle_switch is checked.
-.label:has(.toggle_switch:checked) {
-  background-color: $switch-color-checked;
 }
 
 .ball {
@@ -46,21 +44,26 @@ $ball-color: $white;
   height: $ball-size;
   background-color: $ball-color;
   position: absolute;
-  top: calc(($switch-height - $ball-size) / 2); // Align center vertically.
-  left: 2px;
+  top: $track-padding;
+  left: $track-padding;
   border-radius: 50%;
   transition: transform $toggle-transition;
 }
 
-// Styling on ball when toggle_switch is checked.
-.toggle_switch:checked ~ .ball {
-  transform: translateX(30px); // Move all the way to the end.
+// Styling on track when toggle_switch is checked.
+.toggle_switch:checked + .track {
+  background-color: $switch-color-checked;
+
+  /* stylelint-disable-next-line */
+  .ball {
+    transform: translateX($switch-width - $ball-size - ($track-padding * 2));
+  }
 }
 
-.off_icon {
-  margin-left: -2px;
+.toggle_switch:focus + .track {
+  box-shadow: $focus-box-shadow;
 }
 
-.on_icon {
-  margin-right: -2px;
+.toggle_switch:disabled + .track {
+  cursor: not-allowed;
 }

--- a/frontend/src/Components/ToggleSwitch/ToggleSwitch.stories.tsx
+++ b/frontend/src/Components/ToggleSwitch/ToggleSwitch.stories.tsx
@@ -16,6 +16,3 @@ Basic.args = {};
 
 export const Disabled = Template.bind({});
 Disabled.args = { disabled: true };
-
-export const WithIcons = Template.bind({});
-WithIcons.args = { offIcon: '0', onIcon: '1' };

--- a/frontend/src/Components/ToggleSwitch/ToggleSwitch.tsx
+++ b/frontend/src/Components/ToggleSwitch/ToggleSwitch.tsx
@@ -1,16 +1,13 @@
-import { ReactNode } from 'react';
 import styles from './ToggleSwitch.module.scss';
 
 type ToggleSwitchProps = {
   className?: string;
   checked?: boolean;
-  offIcon?: ReactNode;
-  onIcon?: ReactNode;
   disabled?: boolean;
   onChange?: () => void;
 };
 
-export function ToggleSwitch({ className, checked, onChange, disabled, offIcon, onIcon }: ToggleSwitchProps) {
+export function ToggleSwitch({ className, checked, onChange, disabled }: ToggleSwitchProps) {
   return (
     <div className={className}>
       <label className={styles.label}>
@@ -21,9 +18,9 @@ export function ToggleSwitch({ className, checked, onChange, disabled, offIcon, 
           disabled={disabled}
           onChange={onChange}
         />
-        <span className={styles.off_icon}>{offIcon}</span>
-        <span className={styles.on_icon}>{onIcon}</span>
-        <span className={styles.ball} />
+        <span className={styles.track}>
+          <span className={styles.ball} />
+        </span>
       </label>
     </div>
   );


### PR DESCRIPTION
- The ToggleSwitch looks big and silly, so I've made it smaller.
- Clean up CSS.
    - Remove as much hardcoding as possible. To resize the component you now only need to adjust `$switch-width` and `$switch-height`, the rest will adjust automatically.
- The `:has` CSS selector was just recently supported by default in Firefox, so we can't rely on it.
- Add focus highlight to further support keyboard use.
- Set `not-allowed` cursor when disabled
- Get rid of unused On/Off icons.