### PR TITLE
add generate interviewtime

### DIFF
--- a/backend/samfundet/conftest.py
+++ b/backend/samfundet/conftest.py
@@ -288,6 +288,26 @@ def fixture_recruitment_position(fixture_recruitment: Recruitment, fixture_gang:
 
 
 @pytest.fixture
+def fixture_recruitment_position2(fixture_recruitment: Recruitment, fixture_gang: Gang) -> Iterator[Recruitment]:
+    recruitment_position = RecruitmentPosition.objects.create(
+        name_nb='Position 2 NB',
+        name_en='Position 2 EN',
+        short_description_nb='Short Description NB',
+        short_description_en='Short Description EN',
+        long_description_nb='Long Description NB',
+        long_description_en='Long Description EN',
+        is_funksjonaer_position=False,
+        default_admission_letter_nb='Default Admission Letter NB',
+        default_admission_letter_en='Default Admission Letter EN',
+        tags='tag1,tag2',
+        gang=fixture_gang,
+        recruitment=fixture_recruitment,
+    )
+    yield recruitment_position
+    recruitment_position.delete()
+
+
+@pytest.fixture
 def fixture_informationpage() -> Iterator[InformationPage]:
     informationpage = InformationPage.objects.create(title_nb='Norsk tittel', title_en='Engel', slug_field='Sygard')
     yield informationpage
@@ -316,6 +336,25 @@ def fixture_recruitment_admission(
     admission = RecruitmentAdmission.objects.create(
         admission_text='Test admission text',
         recruitment_position=fixture_recruitment_position,
+        recruitment=fixture_recruitment,
+        user=fixture_user,
+        applicant_priority=1,
+        recruiter_priority=RecruitmentPriorityChoices.NOT_SET,
+        recruiter_status=RecruitmentStatusChoices.NOT_SET,
+    )
+    yield admission
+    admission.delete()
+
+
+@pytest.fixture
+def fixture_recruitment_admission2(
+    fixture_user: User,
+    fixture_recruitment_position2: RecruitmentPosition,
+    fixture_recruitment: Recruitment,
+) -> Iterator[RecruitmentAdmission]:
+    admission = RecruitmentAdmission.objects.create(
+        admission_text='Test admission text',
+        recruitment_position=fixture_recruitment_position2,
         recruitment=fixture_recruitment,
         user=fixture_user,
         applicant_priority=1,

--- a/backend/samfundet/models/recruitment.py
+++ b/backend/samfundet/models/recruitment.py
@@ -178,6 +178,7 @@ class RecruitmentPosition(CustomBaseModel):
                     without_interview = without_interview.exclude(id=admission.id)
                     break
             if len(without_interview) == 0:
+                # If no more without interview, break out
                 break
 
             current_dt += interview_duration

--- a/backend/samfundet/models/recruitment.py
+++ b/backend/samfundet/models/recruitment.py
@@ -132,8 +132,8 @@ class RecruitmentPosition(CustomBaseModel):
             self.default_admission_letter_en = 'No english applicants'
         super().save(*args, **kwargs)
 
-    def generate_interviewhours(
-        self,  # noqa: C901
+    def generate_interviewhours(  # noqa: C901
+        self,
         start_dt: timezone.datetime,
         end_dt: timezone.datetime,
         location: str,

--- a/backend/samfundet/models/recruitment.py
+++ b/backend/samfundet/models/recruitment.py
@@ -132,7 +132,7 @@ class RecruitmentPosition(CustomBaseModel):
             self.default_admission_letter_en = 'No english applicants'
         super().save(*args, **kwargs)
 
-    def generate_inteviewhours(
+    def generate_interviewhours(
         self,  # noqa: C901
         start_dt: timezone.datetime,
         end_dt: timezone.datetime,

--- a/backend/samfundet/models/tests/test_recruitment.py
+++ b/backend/samfundet/models/tests/test_recruitment.py
@@ -288,7 +288,7 @@ class TestRecruitmentInterview:
     ):
         assert fixture_recruitment_admission.interview is None
         assert fixture_recruitment_admission2.interview is None
-
+        assert fixture_recruitment_admission2.recruitment_position != fixture_recruitment_admission.recruitment_position
         # Generate the first interview, other does not generate
         location_name = 'Mujaffas BMW'
         fixture_recruitment_admission.recruitment_position.generate_interviewhours(

--- a/backend/samfundet/serializers.py
+++ b/backend/samfundet/serializers.py
@@ -712,6 +712,13 @@ class OccupiedtimeslotSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class GenerateInterviewSerializer(serializers.Serializer):
+    location = serializers.CharField(required=True, max_length=100)
+    start_dt = serializers.DateTimeField(required=True)
+    end_dt = serializers.DateTimeField(required=True)
+    position = serializers.IntegerField(required=False)
+
+
 class ApplicantInfoSerializer(CustomBaseSerializer):
     occupied_timeslots = OccupiedtimeslotSerializer(many=True)
 

--- a/backend/samfundet/tests/test_views.py
+++ b/backend/samfundet/tests/test_views.py
@@ -23,6 +23,7 @@ from samfundet.models.general import (
     InformationPage,
 )
 from samfundet.models.recruitment import (
+    Interview,
     Recruitment,
     RecruitmentPosition,
     RecruitmentAdmission,
@@ -847,8 +848,9 @@ def test_get_applicants_without_interviews_when_interview_is_set(
     url = reverse(routes.samfundet__applicants_without_interviews)
 
     # Setting the interview time for the user's admission
-    fixture_recruitment_admission.interview.interview_time = timezone.now()
-    fixture_recruitment_admission.interview.save()
+    interview = Interview.objects.create(interview_time=timezone.now(), interview_location='Baghdad')
+    interview.save()
+    fixture_recruitment_admission.interview = interview
     fixture_recruitment_admission.save()
 
     ### Act ###

--- a/backend/samfundet/urls.py
+++ b/backend/samfundet/urls.py
@@ -72,5 +72,6 @@ urlpatterns = [
     path('active-recruitment-positions/', views.ActiveRecruitmentPositionsView.as_view(), name='active_recruitment_positions'),
     path('applicants-without-interviews/', views.ApplicantsWithoutInterviewsView.as_view(), name='applicants_without_interviews/'),
     path('occupiedtimeslot/', views.OccupiedtimeslotView.as_view(), name='occupied_timeslots'),
+    path('generate-interviewhours/<int:pk>/', views.GenerateInterviewsView.as_view(), name='generate_interviews'),
     path('feedback/', views.UserFeedbackView.as_view(), name='feedback'),
 ]

--- a/backend/samfundet/views.py
+++ b/backend/samfundet/views.py
@@ -798,7 +798,7 @@ class GenerateInterviewsView(APIView):
             start_dt = timezone.datetime.strptime(start_dt, '%Y-%m-%dT%H:%M:%S%z')
         if type(end_dt) is str:
             end_dt = timezone.datetime.strptime(end_dt, '%Y-%m-%dT%H:%M:%S%z')
-        new_interviews = position.generate_inteviewhours(start_dt, end_dt, input_data.data['location'])
+        new_interviews = position.generate_interviewhours(start_dt, end_dt, input_data.data['location'])
         return Response(RecruitmentAdmissionForGangSerializer(new_interviews).data, status=status.HTTP_201_CREATED)
 
 


### PR DESCRIPTION
Method that takes in start time, end time and place, and even duration of interviews.
Duration may be changed later, and interviews should have an endtime also, due to some gangs having longer interviews.

added tests, check if clean add single, multiple, and if time is occupied

Method returns admissions that got an interview time

closes #1134 

Could later add an algorithm for multiple dates