### PR TITLE
Fix recruitment gang overview page showing only samf's gangs

### DIFF
--- a/frontend/src/PagesAdmin/RecruitmentGangOverviewPage/RecruitmentGangOverviewPage.tsx
+++ b/frontend/src/PagesAdmin/RecruitmentGangOverviewPage/RecruitmentGangOverviewPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams, useRouteLoaderData } from 'react-router-dom';
 import { Button, Link } from '~/Components';
 import { Table } from '~/Components/Table';
-import { getRecruitmentGangs } from '~/api';
+import { getRecruitmentGangs, withdrawRecruitmentApplicationRecruiter } from '~/api';
 import { type RecruitmentGangDto } from '~/dto';
 import { useTitle } from '~/hooks';
 import { KEY } from '~/i18n/constants';
@@ -23,10 +23,10 @@ export function RecruitmentGangOverviewPage() {
   useTitle(title);
 
   useEffect(() => {
-    if (!recruitment?.organization) {
+    if (!recruitment?.id) {
       return;
     }
-    getRecruitmentGangs(recruitment.organization).then((data) => {
+    getRecruitmentGangs(recruitment.id).then((data) => {
       setGangs(data);
       setLoading(false);
     });

--- a/frontend/src/PagesAdmin/RecruitmentGangOverviewPage/RecruitmentGangOverviewPage.tsx
+++ b/frontend/src/PagesAdmin/RecruitmentGangOverviewPage/RecruitmentGangOverviewPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams, useRouteLoaderData } from 'react-router-dom';
 import { Button, Link } from '~/Components';
 import { Table } from '~/Components/Table';
-import { getRecruitmentGangs, withdrawRecruitmentApplicationRecruiter } from '~/api';
+import { getRecruitmentGangs } from '~/api';
 import { type RecruitmentGangDto } from '~/dto';
 import { useTitle } from '~/hooks';
 import { KEY } from '~/i18n/constants';

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -376,10 +376,9 @@ export async function getGang(id: string | number): Promise<GangDto> {
 }
 
 export async function getRecruitmentGangs(recruitmentId: string | number): Promise<RecruitmentGangDto[]> {
-  const url = BACKEND_DOMAIN + reverse({
-    pattern: ROUTES.backend.samfundet__recruitment_gangs,
-    urlParams: { pk: recruitmentId }
-  });
+  const url =
+    BACKEND_DOMAIN +
+    reverse({ pattern: ROUTES.backend.samfundet__recruitment_gangs, urlParams: { pk: recruitmentId } });
   const response = await axios.get<RecruitmentGangDto[]>(url, { withCredentials: true });
   return response.data;
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -375,8 +375,8 @@ export async function getGang(id: string | number): Promise<GangDto> {
   return response.data;
 }
 
-export async function getRecruitmentGangs(id: string | number): Promise<RecruitmentGangDto[]> {
-  const url = BACKEND_DOMAIN + reverse({ pattern: ROUTES.backend.samfundet__recruitment_gangs, urlParams: { pk: id } });
+export async function getRecruitmentGangs(recruitmentId: string | number): Promise<RecruitmentGangDto[]> {
+  const url = BACKEND_DOMAIN + reverse({ pattern: ROUTES.backend.samfundet__recruitment_gangs, urlParams: { pk: recruitmentId } });
   const response = await axios.get<RecruitmentGangDto[]>(url, { withCredentials: true });
   return response.data;
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -376,7 +376,10 @@ export async function getGang(id: string | number): Promise<GangDto> {
 }
 
 export async function getRecruitmentGangs(recruitmentId: string | number): Promise<RecruitmentGangDto[]> {
-  const url = BACKEND_DOMAIN + reverse({ pattern: ROUTES.backend.samfundet__recruitment_gangs, urlParams: { pk: recruitmentId } });
+  const url = BACKEND_DOMAIN + reverse({
+    pattern: ROUTES.backend.samfundet__recruitment_gangs,
+    urlParams: { pk: recruitmentId }
+  });
   const response = await axios.get<RecruitmentGangDto[]>(url, { withCredentials: true });
   return response.data;
 }


### PR DESCRIPTION
Due to `getRecruitmentGangs` expecting the recruitment ID, _not_ the organization ID