### PR TITLE
Update active recruitment link styling

### DIFF
--- a/frontend/src/Components/Navbar/Navbar.module.scss
+++ b/frontend/src/Components/Navbar/Navbar.module.scss
@@ -401,9 +401,9 @@ offsets the text by 18px, the size of the chevron-icon */
 }
 
 .active_recruitment {
-  background-color: $green;
-  font-weight: 700;
+  background-color: $red-samf;
+  font-weight: bold;
   color: $white;
-  padding: 0.2em 0.4em 0.2em 0.4em;
-  border-radius: 0.4em;
+  border-radius: 0.25rem;
+  padding: 0.5rem 0.75rem;
 }

--- a/frontend/src/Components/Navbar/Navbar.module.scss
+++ b/frontend/src/Components/Navbar/Navbar.module.scss
@@ -402,7 +402,7 @@ offsets the text by 18px, the size of the chevron-icon */
 
 .active_recruitment {
   background-color: $red-samf;
-  font-weight: bold;
+  font-weight: 700;
   color: $white;
   border-radius: 0.25rem;
   padding: 0.5rem 0.75rem;


### PR DESCRIPTION
# Before

<img width="965" alt="image" src="https://github.com/user-attachments/assets/608c0879-671a-4be4-8016-454b3ae6033f">

<img width="965" alt="image" src="https://github.com/user-attachments/assets/3f7b1298-9ab8-4afd-a6c1-c4068b9589da">

# After

<img width="965" alt="image" src="https://github.com/user-attachments/assets/211836af-5bbf-4eb9-84e2-e64ac96497cf">

<img width="965" alt="image" src="https://github.com/user-attachments/assets/b10e5bfd-d0de-48a3-b21e-b7f544c2fe69">
