### PR TITLE
fix: wrong color on header in OrganizationRecruitmentPage

### DIFF
--- a/frontend/src/Pages/OrganizationRecruitmentPage/OrganizationRecruitmentPage.module.scss
+++ b/frontend/src/Pages/OrganizationRecruitmentPage/OrganizationRecruitmentPage.module.scss
@@ -20,6 +20,7 @@
   width: 100%;
   padding: 0.25rem;
   border-radius: 0.15rem;
+  color: white;
 }
 
 .video {


### PR DESCRIPTION
Small css fix for the header so it is white like the other text, instead of black

Before:
<img width="318" alt="Skjermbilde 2024-10-22 kl  19 25 23" src="https://github.com/user-attachments/assets/96c5eaa7-ffcf-4f43-9eb6-05ead9859b4a">
<img width="312" alt="Skjermbilde 2024-10-22 kl  19 25 32" src="https://github.com/user-attachments/assets/d2fe1725-fb86-410c-a8cb-d7d89cea1a4a">
<img width="312" alt="Skjermbilde 2024-10-22 kl  19 25 08" src="https://github.com/user-attachments/assets/41a4e2ce-9a6a-4912-80ca-267f6cd46f56">

After:

<img width="305" alt="Skjermbilde 2024-10-22 kl  19 25 57" src="https://github.com/user-attachments/assets/17c040c8-67fd-459b-9af2-57fa29028d76">
<img width="386" alt="Skjermbilde 2024-10-22 kl  19 26 06" src="https://github.com/user-attachments/assets/1809a0aa-ddc7-4326-932f-d5dfc1fbd6c5">
<img width="305" alt="Skjermbilde 2024-10-22 kl  19 25 49" src="https://github.com/user-attachments/assets/ee992817-b1ec-40fb-996d-5c348b6888b2">



Related to #1476
Closes #1476 