### PR TITLE
Fix some breadcrumbs and clean up other uses

### DIFF
--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -151,7 +151,7 @@ export const router = createBrowserRouter(
           />
           <Route
             path={ROUTES.frontend.admin_gangs_create}
-            handle={{ crumb: () => <Link url={ROUTES.frontend.admin_gangs_create}>{t(KEY.common_create)}</Link> }}
+            handle={{ crumb: ({ pathname }: UIMatch) => <Link url={pathname}>{t(KEY.common_create)}</Link> }}
             element={<PermissionRoute required={[PERM.SAMFUNDET_ADD_GANG]} element={<GangsFormAdminPage />} />}
           />
           <Route
@@ -202,12 +202,12 @@ export const router = createBrowserRouter(
           />
           <Route
             path={ROUTES.frontend.admin_events_create}
-            handle={{ crumb: () => <Link url={ROUTES.frontend.admin_events_create}>{t(KEY.common_create)}</Link> }}
+            handle={{ crumb: ({ pathname }: UIMatch) => <Link url={pathname}>{t(KEY.common_create)}</Link> }}
             element={<PermissionRoute required={[PERM.SAMFUNDET_ADD_EVENT]} element={<EventCreatorAdminPage />} />}
           />
           <Route
             path={ROUTES.frontend.admin_events_edit}
-            handle={{ crumb: () => <Link url={ROUTES.frontend.admin_events_edit}>{t(KEY.common_edit)}</Link> }}
+            handle={{ crumb: ({ pathname }: UIMatch) => <Link url={pathname}>{t(KEY.common_edit)}</Link> }}
             element={<PermissionRoute required={[PERM.SAMFUNDET_CHANGE_EVENT]} element={<EventCreatorAdminPage />} />}
           />
         </Route>
@@ -217,7 +217,7 @@ export const router = createBrowserRouter(
         */}
         <Route
           path={ROUTES.frontend.admin_information}
-          handle={{ crumb: () => <Link url={ROUTES.frontend.admin_information}>{t(KEY.information_page)}</Link> }}
+          handle={{ crumb: ({ pathname }: UIMatch) => <Link url={pathname}>{t(KEY.information_page)}</Link> }}
           element={
             <PermissionRoute required={[PERM.SAMFUNDET_VIEW_INFORMATIONPAGE]} element={<InformationAdminPage />} />
           }
@@ -225,7 +225,7 @@ export const router = createBrowserRouter(
         {/* Opening hours, TODO ADD OPENING HOURS PERMISSIONS*/}
         <Route
           path={ROUTES.frontend.admin_opening_hours}
-          handle={{ crumb: () => <Link url={ROUTES.frontend.admin_opening_hours}>{t(KEY.common_opening_hours)}</Link> }}
+          handle={{ crumb: ({ pathname }: UIMatch) => <Link url={pathname}>{t(KEY.common_opening_hours)}</Link> }}
           element={<PermissionRoute required={[]} element={<OpeningHoursAdminPage />} />}
         />
         {/* Closed period */}
@@ -243,14 +243,14 @@ export const router = createBrowserRouter(
           />
           <Route
             path={ROUTES.frontend.admin_closed_create}
-            handle={{ crumb: () => <Link url={ROUTES.frontend.admin_closed_create}>{t(KEY.common_create)}</Link> }}
+            handle={{ crumb: ({ pathname }: UIMatch) => <Link url={pathname}>{t(KEY.common_create)}</Link> }}
             element={
               <PermissionRoute required={[PERM.SAMFUNDET_ADD_CLOSEDPERIOD]} element={<ClosedPeriodFormAdminPage />} />
             }
           />
           <Route
             path={ROUTES.frontend.admin_closed_edit}
-            handle={{ crumb: () => <Link url={ROUTES.frontend.admin_closed_edit}>{t(KEY.common_edit)}</Link> }}
+            handle={{ crumb: ({ pathname }: UIMatch) => <Link url={pathname}>{t(KEY.common_edit)}</Link> }}
             element={
               <PermissionRoute
                 required={[PERM.SAMFUNDET_CHANGE_CLOSEDPERIOD]}
@@ -270,7 +270,7 @@ export const router = createBrowserRouter(
           />
           <Route
             path={ROUTES.frontend.admin_images_create}
-            handle={{ crumb: () => <Link url={ROUTES.frontend.admin_images_create}>{t(KEY.common_create)}</Link> }}
+            handle={{ crumb: ({ pathname }: UIMatch) => <Link url={pathname}>{t(KEY.common_create)}</Link> }}
             element={<PermissionRoute required={[PERM.SAMFUNDET_ADD_IMAGE]} element={<ImageFormAdminPage />} />}
           />
         </Route>
@@ -288,7 +288,7 @@ export const router = createBrowserRouter(
           <Route
             path={ROUTES.frontend.admin_saksdokumenter_create}
             handle={{
-              crumb: () => <Link url={ROUTES.frontend.admin_saksdokumenter_create}>{t(KEY.common_create)}</Link>,
+              crumb: ({ pathname }: UIMatch) => <Link url={pathname}>{t(KEY.common_create)}</Link>,
             }}
             element={
               <PermissionRoute required={[PERM.SAMFUNDET_ADD_SAKSDOKUMENT]} element={<SaksdokumentFormAdminPage />} />
@@ -296,7 +296,7 @@ export const router = createBrowserRouter(
           />
           <Route
             path={ROUTES.frontend.admin_saksdokumenter_edit}
-            handle={{ crumb: () => <Link url={ROUTES.frontend.admin_saksdokumenter_edit}>{t(KEY.common_edit)}</Link> }}
+            handle={{ crumb: ({ pathname }: UIMatch) => <Link url={pathname}>{t(KEY.common_edit)}</Link> }}
             element={
               <PermissionRoute
                 required={[PERM.SAMFUNDET_CHANGE_SAKSDOKUMENT]}
@@ -308,8 +308,8 @@ export const router = createBrowserRouter(
         <Route
           path={ROUTES.frontend.admin_sulten_menu}
           handle={{
-            crumb: () => (
-              <Link url={ROUTES.frontend.admin_sulten_menu}>
+            crumb: ({ pathname }: UIMatch) => (
+              <Link url={pathname}>
                 {t(KEY.common_sulten)} {t(KEY.common_menu)}
               </Link>
             ),
@@ -351,7 +351,7 @@ export const router = createBrowserRouter(
             element={
               <PermissionRoute required={[PERM.SAMFUNDET_ADD_RECRUITMENT]} element={<RecruitmentFormAdminPage />} />
             }
-            handle={{ crumb: () => <Link url={ROUTES.frontend.admin_recruitment_create}>{t(KEY.common_create)}</Link> }}
+            handle={{ crumb: ({ pathname }: UIMatch) => <Link url={pathname}>{t(KEY.common_create)}</Link> }}
           />
           <Route
             path={ROUTES.frontend.admin_recruitment_gang_all_applications}
@@ -503,10 +503,8 @@ export const router = createBrowserRouter(
                 />
               }
               handle={{
-                crumb: () => (
-                  <Link url={ROUTES.frontend.admin_recruitment_open_to_other_positions}>
-                    {t(KEY.recruitment_applicants_open_to_other_positions)}
-                  </Link>
+                crumb: ({ pathname }: UIMatch) => (
+                  <Link url={pathname}>{t(KEY.recruitment_applicants_open_to_other_positions)}</Link>
                 ),
               }}
             />


### PR DESCRIPTION
Some breadcrumbs were broken due to not using the `reverse` function to add parameters to URL.

Also simplified a lot of cases where the pathname from UIMatch wasn't being used. Using it lets us only have to declare the `path` for a route once. If we change the path one day, we won't have to update the breadcrumb too.

Please note that Routes without a path (i.e `Outlet`) cannot use UIMatch.