### PR TITLE
Only listen to primary button press in TimeslotContainer

### DIFF
--- a/frontend/src/Components/TimeslotContainer/TimeslotContainer.tsx
+++ b/frontend/src/Components/TimeslotContainer/TimeslotContainer.tsx
@@ -157,7 +157,10 @@ export function TimeslotContainer({
               key={timeslot}
               active={active}
               disabled={disabled || false}
-              onMouseDown={() => {
+              onMouseDown={(event) => {
+                if (event.button !== 0) {
+                  return;
+                }
                 toggleTimeslot(selectedDate, timeslot);
                 setDragSetSelected(!active);
               }}


### PR DESCRIPTION
Currently all buttons are listened to, meaning you can right click a timeslot button and it will be toggled, which obviously is not the desired behavior.