### PR TITLE
1597 bug position route not related to recruitment

### DIFF
--- a/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangPosition/GangPosition.tsx
+++ b/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangPosition/GangPosition.tsx
@@ -37,7 +37,7 @@ export function GangPosition({ type, recruitmentPositions }: GangItemProps) {
                 <Link
                   url={reverse({
                     pattern: ROUTES.frontend.recruitment_application,
-                    urlParams: { positionId: pos.id, gangId: gang.id },
+                    urlParams: { positionId: pos.id, recruitmentId: pos.recruitment },
                   })}
                   className={styles.position_short_desc}
                 >

--- a/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangPositionDropdown/GangPositionDropdown.tsx
+++ b/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangPositionDropdown/GangPositionDropdown.tsx
@@ -31,7 +31,7 @@ export function GangPositionDropdown({ type, recruitmentPositions, recruitmentId
                 <Link
                   url={reverse({
                     pattern: ROUTES.frontend.recruitment_application,
-                    urlParams: { positionId: pos.id, gangId: gang.id, recruitmentId: recruitmentId },
+                    urlParams: { positionId: pos.id, recruitmentId: recruitmentId },
                   })}
                   className={styles.position_name}
                 >
@@ -40,7 +40,7 @@ export function GangPositionDropdown({ type, recruitmentPositions, recruitmentId
                 <Link
                   url={reverse({
                     pattern: ROUTES.frontend.recruitment_application,
-                    urlParams: { positionId: pos.id, gangId: gang.id, recruitmentId: recruitmentId },
+                    urlParams: { positionId: pos.id, recruitmentId: recruitmentId },
                   })}
                   className={styles.position_short_desc}
                 >

--- a/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangPositionDropdown/GangPositionDropdown.tsx
+++ b/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangPositionDropdown/GangPositionDropdown.tsx
@@ -7,7 +7,7 @@ import styles from './GangPositionDropdown.module.scss';
 
 type GangItemProps = {
   type: GangTypeDto;
-  recruitmentId: number | string;
+  recruitmentId?: string;
   recruitmentPositions?: RecruitmentPositionDto[];
 };
 

--- a/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangPositionDropdown/GangPositionDropdown.tsx
+++ b/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangPositionDropdown/GangPositionDropdown.tsx
@@ -7,12 +7,13 @@ import styles from './GangPositionDropdown.module.scss';
 
 type GangItemProps = {
   type: GangTypeDto;
+  recruitmentId: number | string;
   recruitmentPositions?: RecruitmentPositionDto[];
 };
 
 //TODO: DO IN ISSUE #1121, only get gang types recruiting from backend
 // TODO: so the filtering should be done from the backend
-export function GangPositionDropdown({ type, recruitmentPositions }: GangItemProps) {
+export function GangPositionDropdown({ type, recruitmentPositions, recruitmentId }: GangItemProps) {
   const filteredGangs = type.gangs
     .map((gang) => {
       const filteredPositions = recruitmentPositions?.filter((pos) => pos.gang.id === gang.id);
@@ -30,7 +31,7 @@ export function GangPositionDropdown({ type, recruitmentPositions }: GangItemPro
                 <Link
                   url={reverse({
                     pattern: ROUTES.frontend.recruitment_application,
-                    urlParams: { positionId: pos.id, gangId: gang.id },
+                    urlParams: { positionId: pos.id, gangId: gang.id, recruitmentId: recruitmentId },
                   })}
                   className={styles.position_name}
                 >
@@ -39,7 +40,7 @@ export function GangPositionDropdown({ type, recruitmentPositions }: GangItemPro
                 <Link
                   url={reverse({
                     pattern: ROUTES.frontend.recruitment_application,
-                    urlParams: { positionId: pos.id, gangId: gang.id },
+                    urlParams: { positionId: pos.id, gangId: gang.id, recruitmentId: recruitmentId },
                   })}
                   className={styles.position_short_desc}
                 >

--- a/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangTypeContainer/GangTypeContainer.tsx
+++ b/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangTypeContainer/GangTypeContainer.tsx
@@ -31,7 +31,12 @@ export function GangTypeContainer({ recruitmentId = '-1' }: GangTypeContainerPro
   ) : (
     <>
       {recruitingGangTypes?.map((gangType) => (
-        <GangPositionDropdown key={gangType.id} type={gangType} recruitmentPositions={recruitmentPositions} />
+        <GangPositionDropdown
+          key={gangType.id}
+          type={gangType}
+          recruitmentPositions={recruitmentPositions}
+          recruitmentId={recruitmentId}
+        />
       ))}
     </>
   );

--- a/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangTypeContainer/GangTypeContainer.tsx
+++ b/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangTypeContainer/GangTypeContainer.tsx
@@ -1,19 +1,17 @@
 import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { SamfundetLogoSpinner } from '~/Components';
 import { getGangList, getRecruitmentPositions } from '~/api';
 import type { GangTypeDto, RecruitmentPositionDto } from '~/dto';
 import { GangPositionDropdown } from '../GangPositionDropdown';
 
-type GangTypeContainerProps = {
-  recruitmentId: string;
-};
-
-export function GangTypeContainer({ recruitmentId = '-1' }: GangTypeContainerProps) {
+export function GangTypeContainer() {
   const [recruitmentPositions, setRecruitmentPositions] = useState<RecruitmentPositionDto[]>();
   const [recruitingGangTypes, setRecruitingGangs] = useState<GangTypeDto[]>();
   const [loading, setLoading] = useState<boolean>(true);
-
+  const { recruitmentId } = useParams();
   useEffect(() => {
+    if (!recruitmentId) return;
     Promise.all([getRecruitmentPositions(recruitmentId), getGangList()])
       .then(([recruitmentRes, gangsRes]) => {
         setRecruitmentPositions(recruitmentRes.data);

--- a/frontend/src/Pages/OrganizationRecruitmentPage/Components/PositionsTable/PositionsTable.tsx
+++ b/frontend/src/Pages/OrganizationRecruitmentPage/Components/PositionsTable/PositionsTable.tsx
@@ -48,7 +48,7 @@ export function PositionsTable({ currentSelectedGang, setLoading, loading }: Pos
   const tableData = positions.map((item) => {
     const positionPageURL = reverse({
       pattern: ROUTES.frontend.recruitment_application,
-      urlParams: { positionId: item.id, gangId: item.id, recruitmentId: recruitmentId },
+      urlParams: { positionId: item.id, recruitmentId: recruitmentId },
     });
     return {
       cells: [

--- a/frontend/src/Pages/OrganizationRecruitmentPage/Components/PositionsTable/PositionsTable.tsx
+++ b/frontend/src/Pages/OrganizationRecruitmentPage/Components/PositionsTable/PositionsTable.tsx
@@ -21,15 +21,15 @@ export function PositionsTable({ currentSelectedGang, setLoading, loading }: Pos
   const [positions, setPositions] = useState<RecruitmentPositionDto[]>([]);
   const navigate = useNavigate();
   const { t } = useTranslation();
-  const recruitmentId = useParams();
+  const { recruitmentId } = useParams();
   const { organizationTheme } = useOrganizationContext();
 
   useEffect(() => {
-    if (!currentSelectedGang || !recruitmentId.recruitmentId) {
+    if (!currentSelectedGang || !recruitmentId) {
       return;
     }
     setLoading(true);
-    getRecruitmentPositionsGangForApplicant(recruitmentId.recruitmentId, currentSelectedGang.id)
+    getRecruitmentPositionsGangForApplicant(recruitmentId, currentSelectedGang.id)
       .then((response) => {
         setPositions(response.data);
         setLoading(false);
@@ -48,7 +48,7 @@ export function PositionsTable({ currentSelectedGang, setLoading, loading }: Pos
   const tableData = positions.map((item) => {
     const positionPageURL = reverse({
       pattern: ROUTES.frontend.recruitment_application,
-      urlParams: { positionId: item.id, gangId: item.id },
+      urlParams: { positionId: item.id, gangId: item.id, recruitmentId: recruitmentId },
     });
     return {
       cells: [

--- a/frontend/src/Pages/OrganizationRecruitmentPage/OrganizationRecruitmentPage.tsx
+++ b/frontend/src/Pages/OrganizationRecruitmentPage/OrganizationRecruitmentPage.tsx
@@ -113,8 +113,7 @@ export function OrganizationRecruitmentPage() {
               <Text>Placeholder for tag-autocomplete search </Text>
               {/*^^^ issue #1275 */}
             </div>
-            {recruitmentId &&
-              (viewAllPositions ? <GangTypeContainer recruitmentId={recruitmentId} /> : <RecruitmentTabs />)}
+            {recruitmentId && (viewAllPositions ? <GangTypeContainer /> : <RecruitmentTabs />)}
             {recruitment?.separate_positions && recruitment.separate_positions.length > 0 && (
               <GangSeparatePositions recruitmentSeparatePositions={recruitment.separate_positions} />
             )}

--- a/frontend/src/Pages/RecruitmentApplicationFormPage/RecruitmentApplicationFormPage.tsx
+++ b/frontend/src/Pages/RecruitmentApplicationFormPage/RecruitmentApplicationFormPage.tsx
@@ -40,7 +40,7 @@ export function RecruitmentApplicationFormPage() {
 
   const [loading, setLoading] = useState(true);
 
-  const { positionId } = useParams();
+  const { positionId, recruitmentId } = useParams();
 
   useTitle(recruitmentPosition ? (dbT(recruitmentPosition, 'name') as string) : '');
 
@@ -175,7 +175,7 @@ export function RecruitmentApplicationFormPage() {
                       navigate({
                         url: reverse({
                           pattern: ROUTES.frontend.recruitment_application,
-                          urlParams: { positionId: pos.id, gangId: pos.gang.id },
+                          urlParams: { positionId: pos.id, recruitmentId: recruitmentId },
                         }),
                       });
                     }}

--- a/frontend/src/Pages/RecruitmentApplicationsOverviewPage/RecruitmentApplicationsOverviewPage.tsx
+++ b/frontend/src/Pages/RecruitmentApplicationsOverviewPage/RecruitmentApplicationsOverviewPage.tsx
@@ -70,7 +70,7 @@ export function RecruitmentApplicationsOverviewPage() {
               pattern: ROUTES.frontend.recruitment_application,
               urlParams: {
                 positionId: application.recruitment_position.id,
-                gangId: application.recruitment_position.gang.id,
+                recruitmentId: recruitmentId,
               },
             })}
             className={styles.position_name}
@@ -131,7 +131,7 @@ export function RecruitmentApplicationsOverviewPage() {
               pattern: ROUTES.frontend.recruitment_application,
               urlParams: {
                 positionId: application.recruitment_position.id,
-                gangId: application.recruitment_position.gang.id,
+                recruitmentId: recruitmentId,
               },
             })}
             className={styles.withdrawnLink}

--- a/frontend/src/PagesAdmin/RecruitmentGangAdminPage/RecruitmentGangAdminPage.tsx
+++ b/frontend/src/PagesAdmin/RecruitmentGangAdminPage/RecruitmentGangAdminPage.tsx
@@ -99,6 +99,7 @@ export function RecruitmentGangAdminPage() {
                     pattern: ROUTES.frontend.recruitment_application,
                     urlParams: {
                       positionId: recruitmentPosition.id,
+                      recruitmentId: recruitmentId,
                     },
                   }),
                 );

--- a/frontend/src/PagesAdmin/RecruitmentRecruiterDashboardPage/RecruitmentRecruiterDashboardPage.tsx
+++ b/frontend/src/PagesAdmin/RecruitmentRecruiterDashboardPage/RecruitmentRecruiterDashboardPage.tsx
@@ -93,6 +93,7 @@ export function RecruitmentRecruiterDashboardPage() {
                   pattern: ROUTES.frontend.recruitment_application,
                   urlParams: {
                     positionId: application.recruitment_position.id,
+                    recruitmentId: recruitmentId,
                   },
                 })}
               >

--- a/frontend/src/routes/frontend.ts
+++ b/frontend/src/routes/frontend.ts
@@ -19,7 +19,8 @@ export const ROUTES_FRONTEND = {
   contributors: '/contributors',
   // Recruitment:
   recruitment: '/recruitment/',
-  recruitment_application: '/recruitment/position/:positionId/',
+  // I ADDED :recruitmentId
+  recruitment_application: '/recruitment/:recruitmentId/position/:positionId/',
   recruitment_application_overview: '/recruitment/:recruitmentId/my-applications/',
   organization_recruitment: '/recruitment/:recruitmentId/',
   contact: '/contact',

--- a/frontend/src/routes/frontend.ts
+++ b/frontend/src/routes/frontend.ts
@@ -19,7 +19,6 @@ export const ROUTES_FRONTEND = {
   contributors: '/contributors',
   // Recruitment:
   recruitment: '/recruitment/',
-  // I ADDED :recruitmentId
   recruitment_application: '/recruitment/:recruitmentId/position/:positionId/',
   recruitment_application_overview: '/recruitment/:recruitmentId/my-applications/',
   organization_recruitment: '/recruitment/:recruitmentId/',


### PR DESCRIPTION
Because recruitmentId was not present in the frontend route recruitment_application ('/recruitment/:recruitmentId/position/:positionId/') the navigation behaviour was buggy. Refactored all but one of the uses of this frontend endpoint. The one I did not refactor is using completely wrong endpoint and will be fixed in another PR.