### PR TITLE
Improve UX of recruitment users without three interview page

### DIFF
--- a/frontend/src/Components/RecruitmentWithoutInterviewTable/RecruitmentWithoutInterviewTable.tsx
+++ b/frontend/src/Components/RecruitmentWithoutInterviewTable/RecruitmentWithoutInterviewTable.tsx
@@ -64,7 +64,7 @@ export function RecruitmentWithoutInterviewTable({ applicants }: RecruitmentWith
         value: user.applications_without_interview ? user.applications_without_interview.length : 0,
         content: (
           <WithoutInterviewModal
-            applications_without_interview={user.applications_without_interview}
+            applicationsWithoutInterview={user.applications_without_interview}
             applications={user.applications}
           />
         ),

--- a/frontend/src/Components/RecruitmentWithoutInterviewTable/RecruitmentWithoutInterviewTable.tsx
+++ b/frontend/src/Components/RecruitmentWithoutInterviewTable/RecruitmentWithoutInterviewTable.tsx
@@ -24,7 +24,7 @@ export function RecruitmentWithoutInterviewTable({ applicants }: RecruitmentWith
     { content: t(KEY.common_phonenumber), sortable: true },
     { content: t(KEY.recruitment_applicant_top_position), sortable: true },
     { content: t(KEY.recruitment_number_of_applications), sortable: true },
-    { content: t(KEY.common_processed), sortable: true },
+    { content: t(KEY.recruitment_interview_planned), sortable: true },
   ];
 
   function filterUsers(): RecruitmentUserDto[] {
@@ -64,6 +64,7 @@ export function RecruitmentWithoutInterviewTable({ applicants }: RecruitmentWith
         value: user.applications_without_interview ? user.applications_without_interview.length : 0,
         content: (
           <WithoutInterviewModal
+            user={user}
             applicationsWithoutInterview={user.applications_without_interview}
             applications={user.applications}
           />

--- a/frontend/src/Components/RecruitmentWithoutInterviewTable/components/WithoutInterviewList.tsx
+++ b/frontend/src/Components/RecruitmentWithoutInterviewTable/components/WithoutInterviewList.tsx
@@ -28,9 +28,11 @@ export function WithoutInterviewList({ applications }: WithoutInterviewListProps
           content: (
             <Link
               url={reverse({
-                pattern: ROUTES.frontend.admin_recruitment_applicant,
+                pattern: ROUTES.frontend.admin_recruitment_gang_position_applicants_overview,
                 urlParams: {
-                  applicationID: application.id,
+                  recruitmentId: application.recruitment,
+                  gangId: application.recruitment_position.gang.id,
+                  positionId: application.recruitment_position.id,
                 },
               })}
             >

--- a/frontend/src/Components/RecruitmentWithoutInterviewTable/components/WithoutInterviewList.tsx
+++ b/frontend/src/Components/RecruitmentWithoutInterviewTable/components/WithoutInterviewList.tsx
@@ -1,7 +1,8 @@
+import { Icon } from '@iconify/react';
 import { useTranslation } from 'react-i18next';
-import { Link } from '~/Components';
+import { Link, Text } from '~/Components';
 import { Table } from '~/Components/Table';
-import type { RecruitmentApplicationDto } from '~/dto';
+import type { RecruitmentApplicationDto, RecruitmentUserDto } from '~/dto';
 import { KEY } from '~/i18n/constants';
 import { reverse } from '~/named-urls';
 import { ROUTES } from '~/routes';
@@ -10,17 +11,23 @@ import styles from './WithoutInterview.module.scss';
 
 type WithoutInterviewListProps = {
   applications: RecruitmentApplicationDto[];
+  user: RecruitmentUserDto;
+  applicationsWithoutInterview: RecruitmentApplicationDto[];
 };
 
-export function WithoutInterviewList({ applications }: WithoutInterviewListProps) {
+export function WithoutInterviewList({ applications, user, applicationsWithoutInterview }: WithoutInterviewListProps) {
   const { t } = useTranslation();
 
   const tableColumns = [
     { content: t(KEY.recruitment_position), sortable: true },
+
+    { content: t(KEY.recruitment_interview_planned), sortable: true },
     { content: t(KEY.recruitment_priority), sortable: true },
   ];
 
   function applicationToRow(application: RecruitmentApplicationDto) {
+    const hasInterview = !applicationsWithoutInterview.some((app) => app.id === application.id);
+
     return {
       cells: [
         {
@@ -40,12 +47,29 @@ export function WithoutInterviewList({ applications }: WithoutInterviewListProps
             </Link>
           ),
         },
+
+        {
+          value: hasInterview ? 1 : 0,
+          content: (
+            <Icon
+              icon={
+                hasInterview
+                  ? 'material-symbols:check-circle-outline-rounded'
+                  : 'material-symbols:close-small-outline-rounded'
+              }
+            />
+          ),
+        },
         application.applicant_priority,
       ],
     };
   }
+
   return (
     <div className={styles.container}>
+      <Text size="l">
+        {user.first_name} {user.last_name}
+      </Text>
       <Table columns={tableColumns} data={applications.map((application) => applicationToRow(application))} />
     </div>
   );

--- a/frontend/src/Components/RecruitmentWithoutInterviewTable/components/WithoutInterviewModal.tsx
+++ b/frontend/src/Components/RecruitmentWithoutInterviewTable/components/WithoutInterviewModal.tsx
@@ -6,10 +6,13 @@ import { WithoutInterviewList } from './WithoutInterviewList';
 
 type WithoutInterviewModalProps = {
   applications: RecruitmentApplicationDto[];
-  applications_without_interview: RecruitmentApplicationDto[];
+  applicationsWithoutInterview: RecruitmentApplicationDto[];
 };
 
-export function WithoutInterviewModal({ applications, applications_without_interview }: WithoutInterviewModalProps) {
+export function WithoutInterviewModal({
+  applications,
+  applicationsWithoutInterview: applications_without_interview,
+}: WithoutInterviewModalProps) {
   const [withoutInterviewModal, setWithoutInterviewModal] = useState(false);
 
   return (

--- a/frontend/src/Components/RecruitmentWithoutInterviewTable/components/WithoutInterviewModal.tsx
+++ b/frontend/src/Components/RecruitmentWithoutInterviewTable/components/WithoutInterviewModal.tsx
@@ -1,24 +1,26 @@
 import { useState } from 'react';
 import { Button, IconButton, Modal } from '~/Components';
-import type { RecruitmentApplicationDto } from '~/dto';
+import type { RecruitmentApplicationDto, RecruitmentUserDto } from '~/dto';
 import styles from './WithoutInterview.module.scss';
 import { WithoutInterviewList } from './WithoutInterviewList';
 
 type WithoutInterviewModalProps = {
+  user: RecruitmentUserDto;
   applications: RecruitmentApplicationDto[];
   applicationsWithoutInterview: RecruitmentApplicationDto[];
 };
 
 export function WithoutInterviewModal({
   applications,
-  applicationsWithoutInterview: applications_without_interview,
+  applicationsWithoutInterview,
+  user,
 }: WithoutInterviewModalProps) {
   const [withoutInterviewModal, setWithoutInterviewModal] = useState(false);
 
   return (
     <>
-      <Button theme="text" onClick={() => setWithoutInterviewModal(true)}>
-        {applications.length - applications_without_interview.length} / {applications.length}
+      <Button theme="outlined" display="pill" onClick={() => setWithoutInterviewModal(true)}>
+        {applications.length - applicationsWithoutInterview.length} / {applications.length}
       </Button>
       <Modal isOpen={withoutInterviewModal}>
         <IconButton
@@ -27,7 +29,12 @@ export function WithoutInterviewModal({
           icon="mdi:close"
           onClick={() => setWithoutInterviewModal(false)}
         />
-        <WithoutInterviewList applications={applications_without_interview} />
+
+        <WithoutInterviewList
+          applicationsWithoutInterview={applicationsWithoutInterview}
+          user={user}
+          applications={applications}
+        />
       </Modal>
     </>
   );

--- a/frontend/src/i18n/constants.ts
+++ b/frontend/src/i18n/constants.ts
@@ -280,6 +280,7 @@ export const KEY = {
   recruitment_interviewer: 'recruitment_interviewer',
   recruitment_interviewers: 'recruitment_interviewers',
   recruitment_interviews: 'recruitment_interviews',
+  recruitment_interview_planned: 'recruitment_interview_planned',
   recruitment_no_interviews: 'recruitment_no_interviews',
   recruitment_interview_set: 'recruitment_interview_set',
   recruitment_interview_groups: 'recruitment_interview_groups',

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -262,6 +262,7 @@ export const nb = prepareTranslations({
   [KEY.recruitment_not_applied]: 'Du har ikke sendt søknader til noen stillinger ennå',
   [KEY.recruitment_will_be_anonymized]: 'All info relatert til dine søknader vil bli slettet 3 uker etter opptaket',
   [KEY.recruitment_interviews]: 'Intervjuer',
+  [KEY.recruitment_interview_planned]: 'Intervjuer planlagt',
   [KEY.recruitment_interviewer]: 'Intervjuer',
   [KEY.recruitment_interviewers]: 'Intervjuere',
   [KEY.recruitment_no_interviews]: 'Ingen intervjuer',
@@ -747,6 +748,7 @@ export const en = prepareTranslations({
   [KEY.recruitment_will_be_anonymized]:
     'All info related to the applications will be anonymized three weeks after the recruitment is over',
   [KEY.recruitment_interviews]: 'Interviews',
+  [KEY.recruitment_interview_planned]: 'Interviews planned',
   [KEY.recruitment_interviewer]: 'Interviewer',
   [KEY.recruitment_interviewers]: 'Interviewers',
   [KEY.recruitment_no_interviews]: 'No interviews',


### PR DESCRIPTION
The UI wa confusing, which lead me to belive that there was a bug. I improved the UX somwhat to reflect better what the data is representing. Also, I changed where the links in the modal naviagtes to. Previously it would navigate to the application the user submitted, but I changed it to navigate to the recruitment gang overview page. I belvie this is more usefull for the recruitment admins which is going to use "users without three interview page"

# Before
![bilde](https://github.com/user-attachments/assets/f66895ad-52db-4f46-9b2f-e9db543aba3b)

### Modal

![bilde](https://github.com/user-attachments/assets/c1ced62c-66d4-4859-8986-34e1d43f0069)

**Links in modal would navigate here:**

![bilde](https://github.com/user-attachments/assets/5f751d9b-df0b-4bc8-8bc1-bfd0a8052680)


# After
![bilde](https://github.com/user-attachments/assets/b8149cb1-a753-43f6-b66a-560d3d2720e4)

### Modal

![bilde](https://github.com/user-attachments/assets/10096da4-36ca-455d-9a32-06e10b3b27e3)

**Links in modal navigates here:**
![bilde](https://github.com/user-attachments/assets/aac707ff-f40b-4bb0-868a-dc312acacae1)

