### PR TITLE
remove possibility to set to called before repri for gangs

### DIFF
--- a/backend/samfundet/models/recruitment.py
+++ b/backend/samfundet/models/recruitment.py
@@ -398,7 +398,6 @@ class RecruitmentApplication(CustomBaseModel):
             )
             if shared_interview:
                 self.interview = shared_interview.interview
-
         super().save(*args, **kwargs)
 
     def get_total_interviews(self) -> int:
@@ -425,6 +424,13 @@ class RecruitmentApplication(CustomBaseModel):
                 if application.recruiter_priority == RecruitmentPriorityChoices.NOT_WANTED:
                     application.applicant_state = RecruitmentApplicantStates.NOT_WANTED
                 application.save()
+
+    def clean_set_recruiter_status(self, status: RecruitmentStatusChoices) -> RecruitmentStatusChoices:
+        if status not in [RecruitmentStatusChoices.CALLED_AND_ACCEPTED, RecruitmentStatusChoices.CALLED_AND_REJECTED]:
+            return status
+        if timezone.now() < self.recruitment.reprioritization_deadline_for_groups:
+            return self.recruiter_status
+        return status
 
 
 class RecruitmentInterviewAvailability(CustomBaseModel):

--- a/backend/samfundet/tests/test_views.py
+++ b/backend/samfundet/tests/test_views.py
@@ -971,8 +971,15 @@ def test_update_application_recruiter_priority_gang(
 
 
 def test_update_application_recruiter_status_gang(
-    fixture_rest_client: APIClient, fixture_user: User, fixture_user2: User, fixture_recruitment_application: RecruitmentApplication
+    fixture_rest_client: APIClient,
+    fixture_recruitment: Recruitment,
+    fixture_user: User,
+    fixture_user2: User,
+    fixture_recruitment_application: RecruitmentApplication,
 ):
+    # Need to find a way to adjust timezone or set the times of recruitment to now
+    # To able to set recruitment to now due to the fields are required to be in future
+
     ### Arrange ###
     fixture_rest_client.force_authenticate(user=fixture_user2)
     fixture_recruitment_application.user = fixture_user2
@@ -1047,7 +1054,11 @@ def test_update_application_recruiter_priority_position(
 
 
 def test_update_application_recruiter_status_position(
-    fixture_rest_client: APIClient, fixture_user: User, fixture_user2: User, fixture_recruitment_application: RecruitmentApplication
+    fixture_rest_client: APIClient,
+    fixture_recruitment: Recruitment,
+    fixture_user: User,
+    fixture_user2: User,
+    fixture_recruitment_application: RecruitmentApplication,
 ):
     ### Arrange ###
     fixture_rest_client.force_authenticate(user=fixture_user2)

--- a/backend/samfundet/views.py
+++ b/backend/samfundet/views.py
@@ -1071,7 +1071,7 @@ class RecruitmentApplicationForGangUpdateStateView(APIView):
             if 'recruiter_priority' in update_serializer.data:
                 application.recruiter_priority = update_serializer.data['recruiter_priority']
             if 'recruiter_status' in update_serializer.data:
-                application.recruiter_status = update_serializer.data['recruiter_status']
+                application.recruiter_status = application.clean_set_recruiter_status(update_serializer.data['recruiter_status'])
             application.save()
             applications = RecruitmentApplication.objects.filter(
                 recruitment_position__gang=application.recruitment_position.gang,
@@ -1097,7 +1097,7 @@ class RecruitmentApplicationForPositionUpdateStateView(APIView):
             if 'recruiter_priority' in update_serializer.data:
                 application.recruiter_priority = update_serializer.data['recruiter_priority']
             if 'recruiter_status' in update_serializer.data:
-                application.recruiter_status = update_serializer.data['recruiter_status']
+                application.recruiter_status = application.clean_set_recruiter_status(update_serializer.data['recruiter_status'])
             application.save()
             application.update_applicant_state()
             applications = RecruitmentApplication.objects.filter(


### PR DESCRIPTION
This has a small problem and cant be tested, therefore probably not safe to add

Disallows setting called status before reprioritization for gangs
The problem is that this does not work with the endpoint testing, as we cant adjust the time of recruitment to be in this time to test actually setting called.
Cant find a way to change timezone to be in that time either, so probably need some help before getting this in

This is only done for endpoint and not for actual model.

closes [#1213](https://github.com/Samfundet/Samfundet4/issues/1213)