### PR TITLE
feat: add error text on lacking text

### DIFF
--- a/frontend/src/hooks.ts
+++ b/frontend/src/hooks.ts
@@ -10,6 +10,7 @@ import type { TextItemValue } from './constants/TextItems';
 import { useAuthContext } from './context/AuthContext';
 import { useGlobalContext } from './context/GlobalContextProvider';
 import type { TextItemDto } from './dto';
+import { STATUS } from './http_status_codes';
 import { LANGUAGES } from './i18n/types';
 
 // Make typescript happy.
@@ -75,9 +76,19 @@ export function useTextItem(key: TextItemValue, language?: string): string | und
   const { i18n } = useTranslation();
   const isNorwegian = (language || i18n.language) === LANGUAGES.NB;
   useEffect(() => {
-    getTextItem(key).then((data) => {
-      setTextItem(data);
-    });
+    getTextItem(key)
+      .then((data) => {
+        setTextItem(data);
+      })
+      .catch((error) => {
+        if (error.request.status === STATUS.HTTP_404_NOT_FOUND) {
+        }
+        setTextItem({
+          key: 'HEST',
+          text_nb: 'ERROR ERROR kontakt MG:WEB om manglende tekst ERROR ERROR',
+          text_en: 'ERROR ERROR contact MG:WEB about lacking text ERROR ERROR',
+        });
+      });
   }, [key]);
   return isNorwegian ? textItem?.text_nb : textItem?.text_en;
 }

--- a/frontend/src/hooks.ts
+++ b/frontend/src/hooks.ts
@@ -84,9 +84,9 @@ export function useTextItem(key: TextItemValue, language?: string): string | und
         if (error.request.status === STATUS.HTTP_404_NOT_FOUND) {
         }
         setTextItem({
-          key: 'HEST',
-          text_nb: 'ERROR ERROR kontakt MG:WEB om manglende tekst ERROR ERROR',
-          text_en: 'ERROR ERROR contact MG:WEB about lacking text ERROR ERROR',
+          key: 'MISSING_TEXTITEM',
+          text_nb: 'ERROR ERROR Manglende tekst, kontakt redaksjon@samfundet.no ERROR ERROR',
+          text_en: 'ERROR ERROR Missing text, contact redaksjon@samfundet.no ERROR ERROR',
         });
       });
   }, [key]);


### PR DESCRIPTION
Seems textitems would just show blank text if text item did not exist, instead just added error message for easier error finding