### PR TITLE
Configure shared volume to enable running generate_routes within docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - ./backend:/app # Mount backend folder to docker image
       - /app/.venv/ # Ignore local virtual environment
+      - ./frontend/src/routes:/frontend/src/routes
     env_file:
       - ./backend/.docker.env # Environment for backend docker
     environment:


### PR DESCRIPTION
Allows you to run the generate_routes command via docker, through 
```
docker compose backend bash
```
and then
```
poetry run python manage.py generate_routes
```

Alternatively 
```
docker compose exec backend bash -c "poetry run python manage.py generate_routes"
```
