### PR TITLE
fix: add check for when filtering positions, such that only positions…

### DIFF
--- a/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangPositionDropdown/GangPositionDropdown.tsx
+++ b/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangPositionDropdown/GangPositionDropdown.tsx
@@ -1,4 +1,4 @@
-import { ExpandableHeader, Link } from '~/Components';
+import { ErrorDisplay, ExpandableHeader, Link } from '~/Components';
 import type { GangTypeDto, RecruitmentPositionDto } from '~/dto';
 import { reverse } from '~/named-urls';
 import { ROUTES } from '~/routes';
@@ -16,7 +16,7 @@ type GangItemProps = {
 export function GangPositionDropdown({ type, recruitmentPositions, recruitmentId }: GangItemProps) {
   const filteredGangs = type.gangs
     .map((gang) => {
-      const filteredPositions = recruitmentPositions?.filter((pos) => pos.gang.id === gang.id);
+      const filteredPositions = recruitmentPositions?.filter((pos) => pos.gang && pos.gang.id === gang.id);
       if (filteredPositions && filteredPositions.length > 0) {
         return (
           <ExpandableHeader

--- a/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangPositionDropdown/GangPositionDropdown.tsx
+++ b/frontend/src/Pages/OrganizationRecruitmentPage/Components/GangPositionDropdown/GangPositionDropdown.tsx
@@ -1,4 +1,4 @@
-import { ErrorDisplay, ExpandableHeader, Link } from '~/Components';
+import { ExpandableHeader, Link } from '~/Components';
 import type { GangTypeDto, RecruitmentPositionDto } from '~/dto';
 import { reverse } from '~/named-urls';
 import { ROUTES } from '~/routes';


### PR DESCRIPTION
- In GangPositionDropdown, add check for when filtering positions, such that only positions with pos.gang attribute gets processed
- Make sure page does not crash if there exists a position that is not linked to a gang (only a section) on the current recruitment 

Related to #1733
Closes #1733 