### PR TITLE
Embed mazemap of Samfundet in the AboutPage 

### DIFF
--- a/frontend/src/Pages/AboutPage/AboutPage.module.scss
+++ b/frontend/src/Pages/AboutPage/AboutPage.module.scss
@@ -79,6 +79,16 @@
 
 .textBox {
   padding: 1.5em;
+  margin-top: 1.5em;
+}
+
+.mapContainer {
+  height: 400px;
+  margin: 1.5em 0;
+
+  @include for-mobile-only {
+    height: 88vh;
+  }
 }
 
 .row {

--- a/frontend/src/Pages/AboutPage/AboutPage.module.scss
+++ b/frontend/src/Pages/AboutPage/AboutPage.module.scss
@@ -82,6 +82,14 @@
   margin-top: 1.5em;
 }
 
+.map {
+  border: 0.01px solid rgb(248, 248, 248);
+  width: 100%;
+  height: 100%;
+  border-radius: 3px;
+  margin-top: 1.5rem;
+}
+
 .mapContainer {
   height: 400px;
   margin: 1.5em 0;

--- a/frontend/src/Pages/AboutPage/AboutPage.tsx
+++ b/frontend/src/Pages/AboutPage/AboutPage.tsx
@@ -66,7 +66,7 @@ export function AboutPage() {
             }}
             allow="geolocation"
             title="Samfundet Map"
-          ></iframe>
+          />
         </section>
 
         <Carousel spacing={1.5} header>

--- a/frontend/src/Pages/AboutPage/AboutPage.tsx
+++ b/frontend/src/Pages/AboutPage/AboutPage.tsx
@@ -56,14 +56,8 @@ export function AboutPage() {
         <h2 className={styles.header}>{t(KEY.venuepage_title)}</h2>
         <section className={styles.mapContainer}>
           <iframe
+            className={styles.map}
             src="https://use.mazemap.com/embed.html#v=1&campusid=107&zlevel=1&center=10.395303,63.42245&zoom=17.8&sharepoitype=poi&sharepoi=1000460543&utm_medium=iframe"
-            style={{
-              border: '0.1px black',
-              width: '100%',
-              height: '100%',
-              borderRadius: '3px',
-              marginTop: '1.5rem',
-            }}
             allow="geolocation"
             title="Samfundet Map"
           />

--- a/frontend/src/Pages/AboutPage/AboutPage.tsx
+++ b/frontend/src/Pages/AboutPage/AboutPage.tsx
@@ -51,18 +51,35 @@ export function AboutPage() {
           {t(KEY.common_our_history).toUpperCase()}
         </Button>
       </div>
-      <h2 className={styles.header2}>{t(KEY.common_venues)}</h2>
 
-      <Carousel spacing={1.5} header>
-        {VENUES.images.map((image) => {
-          return (
-            <div key={image.name}>
-              <div className={styles.venue_bubble} style={backgroundImageFromUrl(image.src)} />
-              <div className={styles.venue_name}>{image.name}</div>
-            </div>
-          );
-        })}
-      </Carousel>
+      <div className={classNames(styles.box, styles.textBox)}>
+        <h2 className={styles.header}>{t(KEY.venuepage_title)}</h2>
+        <section className={styles.mapContainer}>
+          <iframe
+            src="https://use.mazemap.com/embed.html#v=1&campusid=107&zlevel=1&center=10.395303,63.42245&zoom=17.8&sharepoitype=poi&sharepoi=1000460543&utm_medium=iframe"
+            style={{
+              border: '0.1px black',
+              width: '100%',
+              height: '100%',
+              borderRadius: '3px',
+              marginTop: '1.5rem',
+            }}
+            allow="geolocation"
+            title="Samfundet Map"
+          ></iframe>
+        </section>
+
+        <Carousel spacing={1.5} header>
+          {VENUES.images.map((image) => {
+            return (
+              <div key={image.name}>
+                <div className={styles.venue_bubble} style={backgroundImageFromUrl(image.src)} />
+                <div className={styles.venue_name}>{image.name}</div>
+              </div>
+            );
+          })}
+        </Carousel>
+      </div>
 
       <div className={styles.row}>
         <Button className={styles.button} theme="outlined">


### PR DESCRIPTION
- Embed Mazemap iframe in AboutPage
- Defaults to floor 1 of Samfundet (Rundhallen, Daglighallen, Edgar ...)
- Put together in joint box with Venue Carousel with "Kart og lokaler" header
- Adjust height of the map to be larger for mobile devices

**Found here:**  http://localhost:3000/about/


**Desktop devices:**
<img width="490" alt="Skjermbilde 2025-03-18 kl  21 49 39" src="https://github.com/user-attachments/assets/3a2dc31e-6874-4c2b-824a-e7acfd40bd25" />

**Mobile devices:**
<img width="270" alt="image" src="https://github.com/user-attachments/assets/c1dd3a64-af3b-4278-91a4-4a175ba2f5c9" />

Closes #1758 