### PR TITLE
Permissions for recruitmentapplicationforapplicantview

### DIFF
--- a/backend/samfundet/views.py
+++ b/backend/samfundet/views.py
@@ -328,7 +328,7 @@ class RecruitmentApplicationForApplicantView(ModelViewSet):
     Provides CRUD operations with role-based permissions:
     - List/Retrieve: Available to authenticated users for their own applications
     - Create/Update: Available to authenticated users for their own applications
-    - destoy and partial_update gives 405
+    - create, destroy and partial_update gives 405
     This endpoint allows users to manage their own recruitment applications,
     including creating new applications, updating existing ones, and viewing their application history for specific recruitment.
     """

--- a/backend/samfundet/views.py
+++ b/backend/samfundet/views.py
@@ -341,15 +341,15 @@ class RecruitmentApplicationForApplicantView(ModelViewSet):
         """Override get_queryset to filter by current user"""
         return RecruitmentApplication.objects.filter(user=self.request.user)
 
-    def destroy(self, request: Request, *args, **kwargs) -> Response:
+    def destroy(self, request: Request, *args: tuple, **kwargs: dict[str, Any]) -> Response:
         """Override destroy method to disallow deletion"""
         return Response({'detail': 'DELETE operation not allowed.'}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    def partial_update(self, request: Request, *args, **kwargs) -> Response:
+    def partial_update(self, request: Request, *args: tuple, **kwargs: dict[str, Any]) -> Response:
         """Override partial_update method to disallow PATCH requests"""
         return Response({'detail': 'PATCH operation not allowed.'}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    def create(self, request: Request, *args, **kwargs) -> Response:
+    def create(self, request: Request, *args: tuple, **kwargs: dict[str, Any]) -> Response:
         """Override create method to disallow POST requests"""
         # We only PUT; in the update method contains logic for saving a new application
         return Response({'detail': 'POST operation not allowed.'}, status=status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -839,18 +839,6 @@ export async function putRecruitmentPriorityForUser(
   return await axios.put(url, data, { withCredentials: true });
 }
 
-export async function getRecruitmentApplicantForApplicant(
-  recruitment_position: string,
-): Promise<AxiosResponse<RecruitmentApplicationDto>> {
-  const url =
-    BACKEND_DOMAIN +
-    reverse({
-      pattern: ROUTES.backend.samfundet__recruitment_applications_for_applicant_detail,
-      urlParams: { pk: recruitment_position },
-    });
-  return await axios.get(url, { withCredentials: true });
-}
-
 export async function getRecruitmentApplicationsForGang(
   gangId: string,
   recruitmentId: string,


### PR DESCRIPTION
No permissions needed, just filter queryset by authenticated user.

Refactors RecruitmentApplicationForApplicantView to only allow for the owner of the application to read or updated. Any authenticated user can update.
Overrides destroy, partial_update and create to dissalow DELETE, PATCH and POST. 

Creating an application uses PUT.

Overrides DRFs' get_queryset to only return applications created by the authenticated user.

💡 Kind of unrelated: deleted a duplicate API function in api.ts, we had two for the same endpoint and HTTP method, but only one was in use.


close #1723
