### PR TITLE
Fix visibility of events in events page

### DIFF
--- a/backend/root/management/commands/seed_scripts/events.py
+++ b/backend/root/management/commands/seed_scripts/events.py
@@ -22,7 +22,7 @@ from samfundet.models.event import (
 from samfundet.models.general import Venue
 
 # Number of events
-COUNT = 50
+COUNT = 100
 
 # Event time as offset plus/minus today
 DAY_RANGE = 365 // 2
@@ -196,7 +196,7 @@ def do_seed():  # noqa: C901
                 **metadata_this,
                 start_dt=event_start_dt,
                 end_dt=event_end_dt,
-                visibility_from_dt=event_visibility_from_dt - timezone.timedelta(days=random.randint(7, 21)),
+                visibility_from_dt=event_visibility_from_dt - timezone.timedelta(days=random.randint(7, 35)),
                 visibility_to_dt=event_visibility_to_dt,
                 event_group=group,
                 capacity=capacity,


### PR DESCRIPTION
Oki så: grunnen til at vi ser så få events i "arrangement"-siden er fordi at når vi henter events til siden så er filtreringen ganske streng (i forhold til hvordan den er på forsiden f.eks.). Her viser vi bare arrangementer som skal skje i fremtiden og som er satt til å vises, noe som det ikke filtreres for på forsiden. På forsiden vises alle arrangement, uansett hvilken dato de er satt til å vises fra og til. F.eks. en event som har start_dt = 02.10, og en visibility_from_dt = 08.10 vil vises på forsiden men ikke på arrangementsiden (i koden er dette EventsPerDay vs EventsUpcoming). 

Vi kan komme oss unna dette om vi upper sannsynligheten for at en event genereres og at den genereres med en visibility som har inntruffet i seedscriptet.

Usikker på om dette er den beste måten å løse dette på, men det er uansett viktig å implementere strengere filtrering på forsiden til når vi lanserer, slik at events som ikke skal vises, ikke vil vises (f.eks. for funkebilettarrangement). Vi kan evt. la det være som det er (fordi filtreringen skal jo være streng), men de som jobber med arrangement må da gå inn i events.py og endre antall events til sånn.. mange. Men dette føles også litt weird og whack. 