### PR TITLE
Remove inactive codeowners, remove lockfile codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,3 @@
-* @emilte @robines @Snorre98 @andsamfu
-backend/ @robines @Snorre98 @andsamfu
-frontend/ @robines @Snorre98 @andsamfu
-
-# Dependabot change files (for permitting more weebs to approve dependabot)
-
-**/package.json @robines @Snorre98 @andsamfu @snorrekr @Frenje123 @eilifhl @Lidavic @Erichseen 
-**/yarn.lock @robines @Snorre98 @andsamfu @snorrekr @Frenje123 @eilifhl @Lidavic @Erichseen 
-
-**/poetry.lock @robines @Snorre98 @andsamfu @snorrekr @Frenje123 @eilifhl @Lidavic @Erichseen 
-**/pyproject.toml @robines @Snorre98 @andsamfu @snorrekr @Frenje123 @eilifhl @Lidavic @Erichseen 
+* @robines @andsamfu
+backend/ @robines @andsamfu
+frontend/ @robines @andsamfu


### PR DESCRIPTION
Adding codeowners to lockfiles affects more than just dependabot PRs and is annoying.