### PR TITLE
Remove confusing custom ReactNode Children alias

### DIFF
--- a/frontend/src/Components/Button/Button.tsx
+++ b/frontend/src/Components/Button/Button.tsx
@@ -1,6 +1,7 @@
 import { default as classnames } from 'classnames';
+import type { ReactNode } from 'react';
 import { Link } from 'react-router';
-import type { ButtonType, Children } from '~/types';
+import type { ButtonType } from '~/types';
 import styles from './Button.module.scss';
 import type { ButtonDisplay, ButtonTheme } from './types';
 import { displayToStyleMap, themeToStyleMap } from './utils';
@@ -15,7 +16,7 @@ export type ButtonProps = {
   className?: string;
   disabled?: boolean;
   tabIndex?: number;
-  children?: Children;
+  children?: ReactNode;
   preventDefault?: boolean;
   onClick?: () => void;
   title?: string;

--- a/frontend/src/Components/Carousel/Carousel.tsx
+++ b/frontend/src/Components/Carousel/Carousel.tsx
@@ -1,11 +1,10 @@
 import classNames from 'classnames';
 import type { ReactNode } from 'react';
 import { Skeleton } from '~/Components/Skeleton';
-import type { Children } from '~/types';
 import styles from './Carousel.module.scss';
 
 type CarouselProps = {
-  children: Array<Children>;
+  children: Array<ReactNode>;
   header?: ReactNode;
   spacing?: number;
   className?: string;
@@ -21,7 +20,7 @@ export function Carousel({
   header = <Skeleton width={'8em'} />,
   spacing,
 }: CarouselProps) {
-  const wrappedChildren = children.map((child: Children, idx: number) => {
+  const wrappedChildren = children.map((child: ReactNode, idx: number) => {
     return (
       // biome-ignore lint/suspicious/noArrayIndexKey: no other unique value available
       <div className={classNames(styles.itemContainer, itemContainerClass)} key={idx}>

--- a/frontend/src/Components/Countdown/Countdown.tsx
+++ b/frontend/src/Components/Countdown/Countdown.tsx
@@ -1,14 +1,13 @@
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 
 import classNames from 'classnames';
 import { SECOND_MILLIS } from '~/constants';
-import type { Children } from '~/types';
 import styles from './Countdown.module.scss';
 import { calculateTimeLeft, hasReachedTargetDate } from './utils';
 
 type CountdownProps = {
   targetDate: Date;
-  children?: Children;
+  children?: ReactNode;
 };
 
 export function Countdown({ targetDate, children }: CountdownProps) {

--- a/frontend/src/Components/ErrorDisplay/ErrorDisplay.tsx
+++ b/frontend/src/Components/ErrorDisplay/ErrorDisplay.tsx
@@ -1,11 +1,11 @@
+import type { ReactNode } from 'react';
 import { H1 } from '~/Components';
-import type { Children } from '~/types';
 import styles from './ErrorDisplay.module.scss';
 
 interface ErrorDisplayProps {
   header: string;
   message: string;
-  children?: Children;
+  children?: ReactNode;
 }
 
 export function ErrorDisplay({ header, message, children }: ErrorDisplayProps) {

--- a/frontend/src/Components/ExpandableHeader/ExpandableHeader.tsx
+++ b/frontend/src/Components/ExpandableHeader/ExpandableHeader.tsx
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
-import { useState } from 'react';
-import type { Children } from '~/types';
+import { type ReactNode, useState } from 'react';
 import styles from './ExpandableHeader.module.scss';
 
 type HeaderThemes = 'parent' | 'child';
@@ -8,7 +7,7 @@ type HeaderThemes = 'parent' | 'child';
 type ExpandableHeaderProps = {
   className?: string;
   label?: string;
-  children?: Children;
+  children?: ReactNode;
   showByDefault?: boolean;
   theme?: HeaderThemes;
 };

--- a/frontend/src/Components/ExpandableList/ExpandableList.tsx
+++ b/frontend/src/Components/ExpandableList/ExpandableList.tsx
@@ -1,9 +1,9 @@
-import type { Children } from '~/types';
+import type { ReactNode } from 'react';
 import styles from './ExpandableList.module.scss';
 import { useExpandableListContext } from './components/ExpandableListContextProvider/ExpandableListContextProvider';
 
 type ExpandableListProps = {
-  children: Children;
+  children: ReactNode;
   header: string;
   depth: number;
 };

--- a/frontend/src/Components/ExpandableList/components/Child/Child.tsx
+++ b/frontend/src/Components/ExpandableList/components/Child/Child.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
-import type { Children } from '~/types';
+import type { ReactNode } from 'react';
 import styles from './Child.module.scss';
 
 type ChildProps = {
-  children: Children;
+  children: ReactNode;
 };
 
 export function Child({ children }: ChildProps) {

--- a/frontend/src/Components/ExpandableList/components/ExpandableListContextProvider/ExpandableListContextProvider.tsx
+++ b/frontend/src/Components/ExpandableList/components/ExpandableListContextProvider/ExpandableListContextProvider.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, useState } from 'react';
-import type { Children, SetState } from '~/types';
+import { type ReactNode, createContext, useContext, useState } from 'react';
+import type { SetState } from '~/types';
 
 type ExpandableListContextProps = {
   depth: number;
@@ -19,7 +19,7 @@ export function useExpandableListContext() {
 }
 
 type ExpandableListContextProviderProps = {
-  children: Children;
+  children: ReactNode;
 };
 
 export function ExpandableListContextProvider({ children }: ExpandableListContextProviderProps) {

--- a/frontend/src/Components/ExpandableList/components/Parent/Parent.tsx
+++ b/frontend/src/Components/ExpandableList/components/Parent/Parent.tsx
@@ -1,11 +1,10 @@
 import classNames from 'classnames';
-import { useEffect, useState } from 'react';
-import type { Children } from '~/types';
+import { type ReactNode, useEffect, useState } from 'react';
 import { useExpandableListContext } from '../ExpandableListContextProvider/ExpandableListContextProvider';
 import styles from './Parent.module.scss';
 
 type ParentProps = {
-  children: Children;
+  children: ReactNode;
   onClick?: () => void;
   content: string | number;
   nestedDepth?: number;

--- a/frontend/src/Components/ImageCard/ImageCard.tsx
+++ b/frontend/src/Components/ImageCard/ImageCard.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import { Skeleton } from '~/Components';
 import { KEY } from '~/i18n/constants';
-import { type Children, EventTicketType } from '~/types';
+import { EventTicketType } from '~/types';
 import { backgroundImageFromUrl } from '~/utils';
 import { Badge } from '../Badge';
 import { Link } from '../Link';
@@ -22,7 +22,7 @@ type ImageCardProps = {
   localImage?: boolean; // Local image in frontend assets.
   compact?: boolean;
   isSkeleton?: boolean;
-  children?: Children;
+  children?: ReactNode;
   ticket_type?: string;
   host?: string;
 };

--- a/frontend/src/Components/ImagePicker/ImagePicker.tsx
+++ b/frontend/src/Components/ImagePicker/ImagePicker.tsx
@@ -1,10 +1,9 @@
 import { Icon } from '@iconify/react';
 import classNames from 'classnames';
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { getImages } from '~/api';
 import { BACKEND_DOMAIN } from '~/constants';
 import type { ImageDto } from '~/dto';
-import type { Children } from '~/types';
 import { backgroundImageFromUrl } from '~/utils';
 import styles from './ImagePicker.module.scss';
 
@@ -28,7 +27,7 @@ export function ImagePicker({ onSelected, selectedImage }: ImagePickerProps) {
     onSelected?.(image);
   }
 
-  function renderImage(image: ImageDto): Children {
+  function renderImage(image: ImageDto): ReactNode {
     const isSelected = selected?.id === image.id;
     return (
       <button

--- a/frontend/src/Components/InputField/InputField.tsx
+++ b/frontend/src/Components/InputField/InputField.tsx
@@ -1,13 +1,12 @@
 import { Icon } from '@iconify/react';
 import classNames from 'classnames';
-import type { ChangeEvent } from 'react';
-import type { Children } from '~/types';
+import type { ChangeEvent, ReactNode } from 'react';
 import styles from './InputField.module.scss';
 
 export type InputFieldType = 'text' | 'number' | 'email' | 'password' | 'datetime-local' | 'date' | 'time';
 
 export type InputFieldProps<T> = {
-  children?: Children;
+  children?: ReactNode;
   labelClassName?: string;
   inputClassName?: string;
   onChange?: (value: T) => void;

--- a/frontend/src/Components/Link/Link.tsx
+++ b/frontend/src/Components/Link/Link.tsx
@@ -1,8 +1,7 @@
 import classNames from 'classnames';
-import type { CSSProperties } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { BACKEND_DOMAIN } from '~/constants';
 import { useCustomNavigate } from '~/hooks';
-import type { Children } from '~/types';
 import styles from './Link.module.scss';
 
 export type LinkTarget = 'frontend' | 'backend' | 'external' | 'email';
@@ -16,7 +15,7 @@ export type LinkProps = {
   plain?: boolean;
   target?: LinkTarget;
   onAfterClick?: () => void;
-  children?: Children;
+  children?: ReactNode;
 };
 
 export function Link({

--- a/frontend/src/Components/List/List.tsx
+++ b/frontend/src/Components/List/List.tsx
@@ -1,11 +1,11 @@
 import classnames from 'classnames';
-import type { Children } from '~/types';
+import type { ReactNode } from 'react';
 import styles from './List.module.scss';
 
 type ListType = 'ordered' | 'unordered' | 'no_bullets';
 
 type ListProps = {
-  items: Array<Children>;
+  items: Array<ReactNode>;
   type: ListType;
   classNameList?: string;
   classNameListEntries?: string;

--- a/frontend/src/Components/LycheFrame/LycheFrame.tsx
+++ b/frontend/src/Components/LycheFrame/LycheFrame.tsx
@@ -1,8 +1,8 @@
-import type { Children } from '~/types';
+import type { ReactNode } from 'react';
 import styles from './LycheFrame.module.scss';
 
 type LycheFrameProps = {
-  children?: Children;
+  children?: ReactNode;
 };
 
 export function LycheFrame({ children }: LycheFrameProps) {

--- a/frontend/src/Components/Navbar/components/NavbarItem/NavbarItem.tsx
+++ b/frontend/src/Components/Navbar/components/NavbarItem/NavbarItem.tsx
@@ -1,9 +1,10 @@
 import { Icon } from '@iconify/react';
 import classNames from 'classnames';
+import type { ReactNode } from 'react';
 import { Link } from 'react-router';
 import { useGlobalContext } from '~/context/GlobalContextProvider';
 import { useClickOutside, useDesktop } from '~/hooks';
-import type { Children, SetState } from '~/types';
+import type { SetState } from '~/types';
 import styles from '../../Navbar.module.scss';
 
 type NavbarItemProps = {
@@ -11,7 +12,7 @@ type NavbarItemProps = {
   label: string;
   icon?: string;
   labelClassName?: string;
-  dropdownLinks?: Children;
+  dropdownLinks?: ReactNode;
   expandedDropdown?: string;
   setExpandedDropdown: SetState<string>;
 };

--- a/frontend/src/Components/Page/Page.tsx
+++ b/frontend/src/Components/Page/Page.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames';
-import type { Children } from '~/types';
+import type { ReactNode } from 'react';
 import { SamfundetLogoSpinner } from '../SamfundetLogoSpinner';
 import styles from './Page.module.scss';
 
 type PageProps = {
   className?: string;
-  children?: Children;
+  children?: ReactNode;
   loading?: boolean;
 };
 

--- a/frontend/src/Components/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/Components/ProgressBar/ProgressBar.tsx
@@ -1,10 +1,10 @@
 import classNames from 'classnames';
-import type { Children } from '~/types';
+import type { ReactNode } from 'react';
 import styles from './ProgressBar.module.scss';
 
 type ProgressBarProps = {
   className?: string;
-  children?: Children;
+  children?: ReactNode;
   value?: number;
   max?: number;
   fullWidth?: boolean;

--- a/frontend/src/Components/PulseEffect/PulseEffect.tsx
+++ b/frontend/src/Components/PulseEffect/PulseEffect.tsx
@@ -1,11 +1,11 @@
 import classnames from 'classnames';
+import type { ReactNode } from 'react';
 import { THEME } from '~/constants';
 import { useGlobalContext } from '~/context/GlobalContextProvider';
-import type { Children } from '~/types';
 import styles from './PulseEffect.module.scss';
 
 type PulseEffectProps = {
-  children: Children;
+  children: ReactNode;
   className?: string;
 };
 

--- a/frontend/src/Components/RadioButton/RadioButton.tsx
+++ b/frontend/src/Components/RadioButton/RadioButton.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import type { Children } from '~/types';
+import type { ReactNode } from 'react';
 import styles from './RadioButton.module.scss';
 
 type RadioButtonProps = {
@@ -10,7 +10,7 @@ type RadioButtonProps = {
   disabled?: boolean;
   defaultValue?: string | number;
   defaultChecked?: boolean;
-  children?: Children;
+  children?: ReactNode;
   onChange?: () => void;
 };
 

--- a/frontend/src/Components/Select/Select.tsx
+++ b/frontend/src/Components/Select/Select.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import type { Children } from '~/types';
+import type { ReactNode } from 'react';
 import styles from './Select.module.scss';
 
 type Option = {
@@ -16,7 +16,7 @@ type SelectProps = {
   onChange?: (e?: React.ChangeEvent<HTMLSelectElement>) => void;
   value?: string;
   error?: string;
-  children?: Children;
+  children?: ReactNode;
 };
 
 export function Select({

--- a/frontend/src/Components/SpinningBorder/SpinningBorder.tsx
+++ b/frontend/src/Components/SpinningBorder/SpinningBorder.tsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
-import { COLORS, type Children } from '~/types';
+import type { ReactNode } from 'react';
+import { COLORS } from '~/types';
 import { getGlobalBackgroundColor } from '~/utils';
 import styles from './SpinningBorder.module.scss';
 
@@ -11,7 +12,7 @@ type SpinningBorderProps = {
   radius?: string;
   colors?: string[];
   className?: string;
-  children?: Children;
+  children?: ReactNode;
 };
 
 export function SpinningBorder({

--- a/frontend/src/Components/SultenButton/SultenButton.tsx
+++ b/frontend/src/Components/SultenButton/SultenButton.tsx
@@ -1,6 +1,7 @@
 import { default as classnames } from 'classnames';
+import type { ReactNode } from 'react';
 import { Link } from 'react-router';
-import type { ButtonType, Children } from '~/types';
+import type { ButtonType } from '~/types';
 import styles from './SultenButton.module.scss';
 
 type ButtonProps = {
@@ -9,7 +10,7 @@ type ButtonProps = {
   type?: ButtonType;
   className?: string;
   disabled?: boolean;
-  children?: Children;
+  children?: ReactNode;
   onClick?: () => void;
 };
 

--- a/frontend/src/Components/SultenPage/SultenPage.tsx
+++ b/frontend/src/Components/SultenPage/SultenPage.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames';
-import type { Children } from '~/types';
+import type { ReactNode } from 'react';
 import styles from './SultenPage.module.scss';
 
 type PageProps = {
   classNameInner?: string;
   classNameOuter?: string;
-  children?: Children;
+  children?: ReactNode;
 };
 
 /**

--- a/frontend/src/Components/Table/Table.tsx
+++ b/frontend/src/Components/Table/Table.tsx
@@ -1,8 +1,7 @@
 import { Icon } from '@iconify/react';
 import classNames from 'classnames';
-import { Fragment, useState } from 'react';
+import { Fragment, type ReactNode, useState } from 'react';
 import { Skeleton, TimeDisplay } from '~/Components';
-import type { Children } from '~/types';
 import styles from './Table.module.scss';
 
 // Supported cell values for sorting
@@ -12,7 +11,7 @@ type TableCellValue = string | number | Date | boolean;
 type TableColumn = {
   sortable?: boolean;
   hideSortButton?: boolean;
-  content: Children;
+  content: ReactNode;
 };
 
 type TableCell = {
@@ -20,7 +19,7 @@ type TableCell = {
   value?: TableCellValue;
   // Content in cell, eg <b>24 hours</b>
   // If missing, uses value instead.
-  content?: Children;
+  content?: ReactNode;
   style?: string;
 };
 

--- a/frontend/src/Components/Template/Template.tsx
+++ b/frontend/src/Components/Template/Template.tsx
@@ -1,11 +1,11 @@
 import classnames from 'classnames';
+import type { ReactNode } from 'react';
 import { SubTemplate } from '~/Components/Template/components';
-import type { Children } from '~/types';
 import styles from './Template.module.scss';
 
 type TemplateProps = {
   className?: string;
-  children?: Children;
+  children?: ReactNode;
   onClick?: () => void;
 };
 

--- a/frontend/src/Components/Template/components/SubTemplate/SubTemplate.tsx
+++ b/frontend/src/Components/Template/components/SubTemplate/SubTemplate.tsx
@@ -1,10 +1,10 @@
 import classnames from 'classnames';
-import type { Children } from '~/types';
+import type { ReactNode } from 'react';
 import styles from './SubTemplate.module.scss';
 
 type SubTemplateProps = {
   className?: string;
-  children?: Children;
+  children?: ReactNode;
   onClick?: () => void;
 };
 

--- a/frontend/src/Components/Text/Text.tsx
+++ b/frontend/src/Components/Text/Text.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import { textSizes } from '~/constants';
-import type { Children } from '~/types';
 
 type textProps = {
-  children?: Children;
+  children?: ReactNode;
   size?: 'xs' | 's' | 'm' | 'l' | 'xl' | '2xl';
   as?: 'p' | 'strong' | 'u' | 'i' | 'em' | 'mark' | 'del' | 'ins';
   className?: string;
@@ -23,7 +22,7 @@ export function Text({ children, className, size = 'm', as = 'p' }: textProps) {
 
   type TextAttrProps = {
     as: 'p' | 'strong' | 'u' | 'i' | 'em' | 'mark' | 'del' | 'ins';
-    children: Children;
+    children: ReactNode;
     className?: string;
     style?: React.CSSProperties;
   };

--- a/frontend/src/Components/TextAreaField/TextAreaField.tsx
+++ b/frontend/src/Components/TextAreaField/TextAreaField.tsx
@@ -1,10 +1,9 @@
 import classNames from 'classnames';
-import type { ChangeEvent } from 'react';
-import type { Children } from '~/types';
+import type { ChangeEvent, ReactNode } from 'react';
 import styles from './TextAreaField.module.scss';
 
 export type TextAreaFieldProps = {
-  children?: Children;
+  children?: ReactNode;
   className?: string;
   inputClassName?: string;
   labelClassName?: string;

--- a/frontend/src/Components/ToolTip/ToolTip.tsx
+++ b/frontend/src/Components/ToolTip/ToolTip.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import type React from 'react';
+import type { ReactNode } from 'react';
 import { useRef, useState } from 'react';
-import type { Children } from '~/types';
 import { Image } from '../Image';
 import styles from './ToolTip.module.scss';
 import { useTooltipPosition } from './useToolTipPosition';
@@ -13,7 +13,7 @@ type ToolTipProps = {
   alignment?: AlignmentOptions;
   display?: DisplayOptions;
   value?: string;
-  children: Children;
+  children: ReactNode;
   followCursor?: boolean;
   showArrow?: boolean;
 };

--- a/frontend/src/Pages/HomePage/HomePage.tsx
+++ b/frontend/src/Pages/HomePage/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
 import { EventCarousel, LargeCard } from '~/Pages/HomePage/components';
@@ -6,7 +6,6 @@ import { getHomeData } from '~/api';
 import type { HomePageDto, HomePageElementDto } from '~/dto';
 import { useTitle } from '~/hooks';
 import { KEY } from '~/i18n/constants';
-import type { Children } from '~/types';
 import styles from './HomePage.module.scss';
 import { Splash } from './components/Splash/Splash';
 
@@ -29,7 +28,7 @@ export function HomePage() {
       });
   }, [t]);
 
-  function renderElement(key: number, element: HomePageElementDto): Children {
+  function renderElement(key: number, element: HomePageElementDto): ReactNode {
     switch (element.variation) {
       case 'carousel': {
         if (element.events.length > 0) return <EventCarousel key={key} element={element} />;

--- a/frontend/src/Pages/LycheReservationPage/Components/ReservationFormLine/ReservationFormLine.tsx
+++ b/frontend/src/Pages/LycheReservationPage/Components/ReservationFormLine/ReservationFormLine.tsx
@@ -1,11 +1,11 @@
 import classnames from 'classnames';
-import type { Children } from '~/types';
+import type { ReactNode } from 'react';
 import styles from './ReservationFormLine.module.scss';
 
 type ReservationFormLineProps = {
   label: string;
   help_text?: string;
-  children: Children;
+  children: ReactNode;
   underline?: boolean;
 };
 

--- a/frontend/src/PagesAdmin/EventCreatorAdminPage/EventCreatorAdminPage.tsx
+++ b/frontend/src/PagesAdmin/EventCreatorAdminPage/EventCreatorAdminPage.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Icon } from '@iconify/react';
 import classNames from 'classnames';
-import { type ReactElement, useEffect, useState } from 'react';
+import { type ReactElement, type ReactNode, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
@@ -30,7 +30,6 @@ import { useCustomNavigate, usePrevious, useTitle } from '~/hooks';
 import { KEY } from '~/i18n/constants';
 import { ROUTES } from '~/routes';
 import {
-  type Children,
   EventAgeRestriction,
   type EventAgeRestrictionValue,
   EventCategory,
@@ -565,7 +564,7 @@ export function EventCreatorAdminPage() {
   const formValues = form.getValues();
 
   // Event preview on final step
-  const eventPreview: Children = (
+  const eventPreview: ReactNode = (
     <div className={styles.preview}>
       <ImageCard
         title={dbT(formValues, 'title') ?? ''}
@@ -618,7 +617,7 @@ export function EventCreatorAdminPage() {
   ) : null;
 
   // Navigation buttons
-  const navigationButtons: Children = (
+  const navigationButtons: ReactNode = (
     <div className={styles.button_row}>
       {currentFormTab.key !== createSteps[0].key ? (
         <Button theme="blue" rounded={true} onClick={navigateTabs(-1)}>

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,7 +1,7 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { type ReactNode, createContext, useContext, useEffect, useState } from 'react';
 import { getUser } from '~/api';
 import type { UserDto } from '~/dto';
-import type { Children, SetState } from '~/types';
+import type { SetState } from '~/types';
 
 type AuthContextProps = {
   user: UserDto | undefined;
@@ -23,7 +23,7 @@ export function useAuthContext() {
 
 type AuthContextProviderProps = {
   enabled?: boolean; // Enable/disable all side-effects, useful when used in Storybook.
-  children: Children;
+  children: ReactNode;
 };
 
 export function AuthContextProvider({ children, enabled = true }: AuthContextProviderProps) {

--- a/frontend/src/context/GlobalContextProvider.tsx
+++ b/frontend/src/context/GlobalContextProvider.tsx
@@ -1,9 +1,9 @@
 import axios from 'axios';
-import { createContext, useContext, useEffect, useState } from 'react';
+import { type ReactNode, createContext, useContext, useEffect, useState } from 'react';
 import { getCsrfToken, getKeyValues, putUserPreference } from '~/api';
 import { MIRROR_CLASS, MOBILE_NAVIGATION_OPEN, type ThemeValue, XCSRFTOKEN } from '~/constants';
 import { useMouseTrail, useTheme } from '~/hooks';
-import type { Children, KeyValueMap, SetState } from '~/types';
+import type { KeyValueMap, SetState } from '~/types';
 import { useAuthContext } from './AuthContext';
 
 /**
@@ -56,7 +56,7 @@ export function useGlobalContext() {
 
 type GlobalContextProviderProps = {
   enabled?: boolean; // Enable/disable all side-effects, useful when used in Storybook.
-  children: Children;
+  children: ReactNode;
 };
 
 export function GlobalContextProvider({ children, enabled = true }: GlobalContextProviderProps) {

--- a/frontend/src/context/OrgContextProvider.tsx
+++ b/frontend/src/context/OrgContextProvider.tsx
@@ -1,5 +1,13 @@
-import { type Dispatch, type SetStateAction, createContext, useContext, useEffect, useState } from 'react';
-import { COLORS, type Children, OrgNameType, type OrgNameTypeValue, type OrganizationTheme } from '~/types';
+import {
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import { COLORS, OrgNameType, type OrgNameTypeValue, type OrganizationTheme } from '~/types';
 
 export const organizationThemes: Record<OrgNameTypeValue, OrganizationTheme> = {
   [OrgNameType.SAMFUNDET_NAME]: {
@@ -45,7 +53,7 @@ export function useOrganizationContext() {
 
 type OrganizationContextProviderProps = {
   enabled?: boolean;
-  children: Children;
+  children: ReactNode;
   organization?: OrgNameTypeValue;
 };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,4 +1,4 @@
-import type { Dispatch, ReactNode, SetStateAction } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import type { themeToStyleMap } from '~/Components/Button/utils';
 import type { KV } from '~/constants';
 /** Module for global generic types. */
@@ -14,9 +14,6 @@ export type KeyValueMap = Map<string, string>;
 
 /** Type for the constant of KeyValue keys in the database. */
 export type Key = (typeof KV)[keyof typeof KV];
-
-/** Synonym for ReactNode, but easier to remember. */
-export type Children = ReactNode;
 
 /**Duplicate of colors and hex from _constants.scss */
 export const COLORS = {


### PR DESCRIPTION
Utterly useless abstraction. Using ReactNode is normal in React projects, we shouldn't try to hide it through a custom alias.