### PR TITLE
Improve control panel design

### DIFF
--- a/frontend/src/Components/Breadcrumb/Breadcrumb.module.scss
+++ b/frontend/src/Components/Breadcrumb/Breadcrumb.module.scss
@@ -1,21 +1,43 @@
 @use 'src/constants' as *;
 
-@use 'src/mixins' as *;
+@use '../../mixins' as m;
+
+@use '../../styles/colors' as col;
 
 .breadcrumb {
   display: flex;
   padding: 1rem 0;
   margin: 0;
+  gap: 0.25rem;
+}
+
+.crumb {
+  display: flex;
+  align-items: center;
 }
 
 .separator {
-  margin: 0 0.3rem;
-  user-select: none;
+  color: col.$gray-300;
+
+  @include m.theme-dark {
+    color: col.$gray-600;
+  }
 }
 
-.link {
+.breadcrumb a, .link {
   display: flex;
   align-items: center;
+  color: col.$gray-800;
+
+  @include m.theme-dark {
+    color: col.$gray-200;
+  }
+}
+
+.crumb:last-child {
+  a, .link {
+    font-weight: 500;
+  }
 }
 
 .icon {

--- a/frontend/src/Components/Breadcrumb/Breadcrumb.tsx
+++ b/frontend/src/Components/Breadcrumb/Breadcrumb.tsx
@@ -1,17 +1,9 @@
 import { Icon } from '@iconify/react';
-import type { ReactNode } from 'react';
-import { type UIMatch, useMatches } from 'react-router';
+import { useMatches } from 'react-router';
 import { Link } from '~/Components';
 import { ROUTES } from '~/routes';
+import type { MatchWithCrumb } from '~/types';
 import styles from './Breadcrumb.module.scss';
-
-type HandleWithCrumb = {
-  crumb: (match: UIMatch, data?: unknown) => ReactNode;
-};
-
-interface MatchWithCrumb extends UIMatch {
-  handle: HandleWithCrumb;
-}
 
 export function Breadcrumb() {
   const matches = useMatches();
@@ -27,8 +19,8 @@ export function Breadcrumb() {
       </Link>
       {crumbs.map((crumb, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: no other unique value available
-        <div key={i}>
-          <span className={styles.separator}>&gt;</span>
+        <div key={i} className={styles.crumb}>
+          <Icon icon="carbon:chevron-right" className={styles.separator} />
           {crumb}
         </div>
       ))}

--- a/frontend/src/Components/Skeleton/Skeleton.module.scss
+++ b/frontend/src/Components/Skeleton/Skeleton.module.scss
@@ -30,7 +30,7 @@
   }
 
   @include m.theme-dark {
-    background-color: c.$gray-850;
+    background-color: c.$black-600;
     border: 1px solid c.$gray-950;
 
     &::after {

--- a/frontend/src/PagesAdmin/AdminLayout/AdminLayout.module.scss
+++ b/frontend/src/PagesAdmin/AdminLayout/AdminLayout.module.scss
@@ -1,32 +1,24 @@
-@use 'src/constants' as *;
+@use '../../constants' as c;
 
-@use 'src/mixins' as *;
+@use '../../mixins' as m;
 
-$panel-width: 18em;
-$panel-light-bg: #f6f6f6;
-$panel-light-bg-hover: #e8e8e8;
-$panel-light-border: #d7d7d7;
-$panel-dark-bg: #333333;
+@use '../../styles/colors' as col;
 
 .wrapper {
   display: flex;
   flex-direction: row;
-  max-height: calc(100vh - $navbar-height);
-  height: calc(100vh - $navbar-height);
-  margin-top: $navbar-height;
+  max-height: calc(100vh - #{c.$navbar-height});
+  height: calc(100vh - #{c.$navbar-height});
+  margin-top: c.$navbar-height;
 
-  @include for-mobile-down {
+  @include m.for-mobile-down {
     flex-direction: column;
   }
 }
 
 .panel {
-  position: fixed;
-  height: calc(100% - $navbar-height);
-  min-width: $panel-width;
-  max-width: $panel-width;
-  background-color: $panel-light-bg;
-  border-right: 1px solid $panel-light-border;
+  background-color: col.$white-50;
+  border-right: 1px solid col.$gray-100;
   display: flex;
   flex-direction: column;
   gap: 0.2em;
@@ -36,117 +28,142 @@ $panel-dark-bg: #333333;
   opacity: 1;
   transition: transform 0.2s ease-in-out;
   padding-bottom: 2.5em;
+  position: relative;
 
-  @include for-mobile-only {
+  @include m.for-mobile-only {
+    position: fixed;
+    height: calc(100% - #{c.$navbar-height});
     box-shadow: 0 0 10px 3px rgba(0, 0, 0, 0.1);
     width: 80%;
     max-width: initial;
   }
 
-  @include theme-dark {
-    background-color: $panel-dark-bg;
-    border-color: $black;
+  @include m.theme-dark {
+    background-color: col.$gray-950;
+    border-color: col.$gray-800;
   }
 }
 
-.mobile_panel_closed {
-  transform: translateX(-100%);
+.panel_closed {
+  @include m.for-mobile-down {
+    transform: translateX(-100%);
+  }
 }
 
-.mobile_header {
-  padding: 1rem;
+.panel:not(.panel_closed) {
+  min-width: 250px;
 }
 
-.mobile_panel_close_btn {
-  position: absolute;
-  right: 0.5rem;
-  top: 0.5rem;
+.mobile_open_button {
+  padding: 1.5rem 0.25rem;
+  position: fixed;
+  background-color: col.$black-900;
+  color: col.$white-50;
+  border: none;
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  cursor: pointer;
+  opacity: 0.8;
+  backdrop-filter: blur(16px);
+  transition: opacity 0.1s ease-in-out;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  @include m.theme-dark {
+    background-color: col.$white-50;
+    color: col.$black-900;
+  }
+}
+
+.mobile_panel_backdrop {
+  display: none;
+  @include m.for-mobile-only {
+    display: initial;
+    border: none;
+    border-radius: 0;
+    position: fixed;
+    z-index: 2;
+    background-color: rgba(0, 0, 0, 0.7);
+    width: 100%;
+    height: 100%;
+    backdrop-filter: blur(2px);
+  }
+}
+
+.panel_close_btn {
   padding: 0.5rem;
   margin: 0;
   background: none;
   border: none;
-  border-radius: 0;
   cursor: pointer;
-  color: $grey-1;
+  color: col.$gray-500;
+  border-radius: 0.5em;
 
   &:hover {
-    color: $black;
+    color: c.$black;
+    background: col.$gray-50;
   }
 
-  @include theme-dark {
-    color: $grey-3;
+  @include m.theme-dark {
+    color: col.$gray-100;
 
     &:hover {
-      color: $grey-4;
+      background-color: col.$gray-800;
     }
   }
 }
 
-.mobile_backdrop {
-  width: 100%;
-  height: 100%;
-  position: fixed;
-  z-index: 5;
-  opacity: 0;
-  transition: opacity 0.2s ease-in-out;
-  pointer-events: none;
-  backdrop-filter: blur(2px);
-}
-
-.mobile_backdrop_open {
-  opacity: 1;
-  pointer-events: initial;
-}
-
 .panel_header {
-  @include flex-row;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   font-weight: 700;
   font-size: 1.25em;
-  padding: 0.75em;
-  padding-top: 0.5em;
+  padding: 0.5em 0.75em 0.75em;
   margin-top: 0.25em;
-  gap: 0.5em;
 
-  @include theme-dark {
-    border-color: $grey-1;
+  @include m.theme-dark {
+    border-color: c.$grey-1;
   }
 }
 
 .category_header {
-  font-weight: 700;
+  font-weight: 600;
   padding-left: 1.25em;
   padding-bottom: 0.5em;
 }
 
 .panel_item {
-  @include flex-row;
+  @include m.flex-row;
   text-align: right;
   gap: 1em;
-  padding: 0.5em 0.5em;
-  padding-left: 1em;
+  padding: 0.5em 0.5em 0.5em 1em;
   margin-left: 0.5em;
   margin-right: 0.5em;
   cursor: pointer;
   transition: 0.2s;
-  color: $grey-1;
+  color: c.$grey-1;
   text-decoration: none;
   border-radius: 0.5em;
   white-space: nowrap;
 
-  @include theme-dark {
-    color: $grey-4;
+  @include m.theme-dark {
+    color: col.$gray-100;
   }
 
   &:hover {
     text-decoration: none;
-    background-color: $panel-light-bg-hover;
+    background-color: col.$gray-50;
 
-    @include theme-dark {
-      background-color: $grey-1;
+    @include m.theme-dark {
+      background-color: col.$gray-800;
     }
   }
 }
-
 
 .panel_item_button {
   background: none;
@@ -158,29 +175,31 @@ $panel-dark-bg: #333333;
 }
 
 .selected {
-  background-color: $red-samf;
-  color: white;
-  @include theme-dark {
-    background-color: $red-samf;
+  background-color: col.$red-50;
+  color: col.$samf-red-700;
+  font-weight: 500;
+
+  @include m.theme-dark {
+    background-color: col.$red-900;
+    color: col.$samf-red-500;
+
+    &:hover {
+      background-color: col.$red-800;
+    }
   }
 
   &:hover {
-    background-color: $red-samf;
-    color: white;
+    background-color: col.$red-100;
   }
 }
 
 .content_wrapper {
   flex: 1;
-  height: calc(100vh - $navbar-height);
-  margin-left: calc($panel-width);
-  max-width: calc(100vw - $panel-width);
-  width: calc(100vw - $panel-width);
+  overflow: auto;
+  background-color: col.$white-300;
 
-  @include for-mobile-only {
-    width: auto;
-    max-width: 100%;
-    margin-left: 0;
+  @include m.theme-dark {
+    background-color: col.$black-800;
   }
 }
 
@@ -190,34 +209,6 @@ $panel-dark-bg: #333333;
   width: 100%;
 }
 
-.open_panel_desktop {
-  position: fixed;
-  height: 100%;
-  padding: 0.2em;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-
-  &:hover {
-    background-color: $black-t10;
-    transition: background-color 200ms linear;
-  }
-  &:active {
-    background-color: $black-t25;
-    transition: background-color 1ms linear;
-  }
-}
-
-.arrow {
-  color: $grey-2;
-  background-color: transparent;
-  @include theme-dark {
-    background-color: $grey-4;
-  }
-}
-
 .bottom_items {
   margin-top: auto;
 }
@@ -225,9 +216,10 @@ $panel-dark-bg: #333333;
 .separator {
   width: 80%;
   margin: 0.5em auto;
-  border-top: 1px solid $panel-light-border;
+  border: none;
+  border-top: 1px solid col.$gray-100;
 
-  @include theme-dark {
-    border-color: $grey-1;
+  @include m.theme-dark {
+    border-color: c.$grey-1;
   }
 }

--- a/frontend/src/PagesAdmin/AdminLayout/AdminLayout.tsx
+++ b/frontend/src/PagesAdmin/AdminLayout/AdminLayout.tsx
@@ -1,17 +1,16 @@
 import { Icon } from '@iconify/react';
 import classNames from 'classnames';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback } from 'react';
 import { useCookies } from 'react-cookie';
 import { useTranslation } from 'react-i18next';
-import { Outlet, useLocation } from 'react-router';
-import { useNavigate } from 'react-router';
-import { Button, Link } from '~/Components';
+import { Outlet, useLocation, useNavigate } from 'react-router';
+import { Link } from '~/Components';
 import { Navbar } from '~/Components/NavbarSamfThree';
 import { appletCategories } from '~/Pages/AdminPage/applets';
 import { logout, stopImpersonatingUser } from '~/api';
 import { isSiteFeatureEnabled } from '~/constants/site-features';
 import { useAuthContext } from '~/context/AuthContext';
-import { useMobile } from '~/hooks';
+import { useMobile, useSidePanelState } from '~/hooks';
 import { STATUS } from '~/http_status_codes';
 import { KEY } from '~/i18n/constants';
 import { ROUTES } from '~/routes';
@@ -27,12 +26,12 @@ import styles from './AdminLayout.module.scss';
  */
 export function AdminLayout() {
   const { t } = useTranslation();
-  const [panelOpen, setPanelOpen] = useState(false);
   const isMobile = useMobile();
+  const [isPanelOpen, setPanelOpen] = useSidePanelState();
   const location = useLocation();
   const navigate = useNavigate();
   const [cookies] = useCookies(['impersonated_user_id']);
-  const { user, setUser, loading: authLoading } = useAuthContext();
+  const { setUser, loading: authLoading } = useAuthContext();
 
   const isImpersonating = Object.hasOwn(cookies, 'impersonated_user_id');
 
@@ -57,32 +56,29 @@ export function AdminLayout() {
 
   const makeAppletShortcut = useCallback(
     (applet: AdminApplet, index: number) => {
-      // No default url, dont show in navmenu
+      // No default url, don't show in navmenu
       if (applet.url === undefined) return <></>;
 
-      // Create panel item
-      const selected = location.pathname === applet.url;
+      // TODO: replace hacky solution of excluding /control-panel/. Maybe we can check breadcrumbs for a match?
+      const selected =
+        location.pathname === applet.url ||
+        (location.pathname.startsWith(applet.url) && !applet.url.endsWith('/control-panel/'));
+
       return (
         <Link
           key={index}
           className={classNames(styles.panel_item, selected && styles.selected)}
           url={applet.url}
-          onAfterClick={() => isMobile && panelOpen && setPanelOpen(false)}
+          onAfterClick={() => isMobile && isPanelOpen && setPanelOpen(false)}
           plain={true}
         >
           <Icon icon={applet.icon} />
-          {dbT(applet, 'title')}
+          {isPanelOpen && dbT(applet, 'title')}
         </Link>
       );
     },
-    [location, isMobile, panelOpen],
+    [location, isMobile, isPanelOpen, setPanelOpen],
   );
-
-  useEffect(() => {
-    if (!isMobile) {
-      setPanelOpen(true);
-    }
-  }, [isMobile]);
 
   const userAppletsRaw: AdminApplet[] = [
     { url: ROUTES_FRONTEND.admin, icon: 'mdi:person', title_nb: 'Profil', title_en: 'Profile', feature: 'profile' },
@@ -98,91 +94,95 @@ export function AdminLayout() {
   const userApplets = userAppletsRaw.filter((a) => !a.feature || isSiteFeatureEnabled(a.feature));
 
   const panel = (
-    <div className={classNames(styles.panel, !panelOpen && styles.mobile_panel_closed)}>
-      <button type="button" className={styles.mobile_panel_close_btn} onClick={() => setPanelOpen(false)}>
-        <Icon icon="mdi:close" width={24} />
-      </button>
+    <>
+      <div className={classNames(styles.panel, !isPanelOpen && styles.panel_closed)}>
+        <div className={styles.panel_header}>
+          {isPanelOpen && <span>{t(KEY.control_panel_title)}</span>}
+          <button type="button" className={styles.panel_close_btn} onClick={() => setPanelOpen(!isPanelOpen)}>
+            <Icon icon="lucide:arrow-left-from-line" rotate={isPanelOpen ? 0 : 2} />
+          </button>
+        </div>
+        {userApplets.map((applet, index) => makeAppletShortcut(applet, index))}
 
-      {/* Header */}
-      <div className={styles.panel_header}>{t(KEY.control_panel_title)}</div>
-      {/* Index */}
-      {userApplets.map((applet, index) => makeAppletShortcut(applet, index))}
-      <br />
-      {/* Applets */}
-      {appletCategories.map((category) => {
-        // Keep only the applets with enabled features visible
-        const visibleApplets = category.applets.filter(
-          (applet) => !applet.feature || isSiteFeatureEnabled(applet.feature),
-        );
+        <br />
 
-        if (visibleApplets.length === 0) return null;
+        {appletCategories.map((category) => {
+          // Keep only the applets with enabled features visible
+          const visibleApplets = category.applets.filter(
+            (applet) => !applet.feature || isSiteFeatureEnabled(applet.feature),
+          );
 
-        return (
-          <React.Fragment key={category.title_en}>
-            <div className={styles.category_header}>{dbT(category, 'title')}</div>
-            {visibleApplets.map((applet, index) => makeAppletShortcut(applet, index))}
-          </React.Fragment>
-        );
-      })}
-      <br />
+          if (visibleApplets.length === 0) return null;
 
-      {/* TODO help/faq (Hidden until ready)*/}
-      {isSiteFeatureEnabled('faq') && (
-        <Link className={classNames(styles.panel_item)} url={ROUTES_FRONTEND.admin}>
-          <Icon icon="material-symbols:question-mark-rounded" />
-          {t(KEY.control_panel_faq)}
-        </Link>
-      )}
+          return (
+            <React.Fragment key={category.title_en}>
+              {isPanelOpen ? (
+                <div className={styles.category_header}>{dbT(category, 'title')}</div>
+              ) : (
+                <hr className={styles.separator} />
+              )}
 
-      <div className={styles.bottom_items}>
-        <div className={styles.separator} />
-        {/* Stop Impersonating */}
-        {isImpersonating && (
+              {visibleApplets.map((applet, index) => makeAppletShortcut(applet, index))}
+            </React.Fragment>
+          );
+        })}
+        <br />
+
+        {/* TODO help/faq (Hidden until ready)*/}
+        {isSiteFeatureEnabled('faq') && (
+          <Link className={classNames(styles.panel_item)} url={ROUTES_FRONTEND.admin}>
+            <Icon icon="material-symbols:question-mark-rounded" />
+            {t(KEY.control_panel_faq)}
+          </Link>
+        )}
+
+        <div className={styles.bottom_items}>
+          <hr className={styles.separator} />
+
+          {isImpersonating && (
+            <button
+              type="button"
+              className={classNames(styles.panel_item, styles.panel_item_button)}
+              onClick={handleStopImpersonating}
+            >
+              <Icon icon="ri:spy-fill" />
+              {t(KEY.admin_stop_impersonate)}
+            </button>
+          )}
+
+          <Link
+            url={ROUTES.frontend.admin_mdb_connect}
+            className={classNames(styles.panel_item, {
+              [styles.selected]: location.pathname === ROUTES.frontend.admin_mdb_connect,
+            })}
+          >
+            <Icon icon="mdi:connection" />
+            {isPanelOpen && t(KEY.common_member_database)}
+          </Link>
+
           <button
             type="button"
             className={classNames(styles.panel_item, styles.panel_item_button)}
-            onClick={handleStopImpersonating}
+            onClick={handleLogout}
           >
-            <Icon icon="ri:spy-fill" />
-            {t(KEY.admin_stop_impersonate)}
+            <Icon icon="material-symbols:logout" />
+            {isPanelOpen && t(KEY.common_logout)}
           </button>
-        )}
-        {/** Connect to MDB button */}
-        <Link
-          url={ROUTES.frontend.admin_mdb_connect}
-          className={classNames(styles.panel_item, {
-            [styles.selected]: location.pathname === ROUTES.frontend.admin_mdb_connect,
-          })}
-        >
-          <Icon icon="mdi:connection" />
-          {t(KEY.common_member_database)}
-        </Link>
-        {/* Logout */}
+        </div>
+      </div>
+      {isPanelOpen && isMobile && (
         <button
           type="button"
-          className={classNames(styles.panel_item, styles.panel_item_button)}
-          onClick={handleLogout}
-        >
-          <Icon icon="material-symbols:logout" />
-          {t(KEY.common_logout)}
-        </button>
-      </div>
-    </div>
-  );
-
-  const mobileOpen = (
-    <>
-      <div className={styles.mobile_header}>
-        <Button theme="primary" onClick={() => setPanelOpen(!panelOpen)}>
-          <Icon icon="ci:hamburger-md" /> {t(KEY.common_open)} {t(KEY.control_panel_title)}
-        </Button>
-      </div>
+          className={classNames(styles.mobile_panel_backdrop)}
+          onClick={() => setPanelOpen(false)}
+        />
+      )}
     </>
   );
 
-  const desktopOpen = (
-    <button type="button" className={styles.open_panel_desktop} onClick={() => setPanelOpen(true)}>
-      <Icon icon="mdi:arrow-right-bold" width={16} className={styles.arrow} />
+  const mobileOpen = (
+    <button type="button" className={styles.mobile_open_button} onClick={() => setPanelOpen(true)}>
+      <Icon icon="carbon:chevron-right" />
     </button>
   );
 
@@ -192,9 +192,9 @@ export function AdminLayout() {
       {!authLoading && (
         <div className={styles.wrapper}>
           {panel}
-          {!panelOpen && (isMobile ? mobileOpen : desktopOpen)}
-          {/* Content */}
-          <div className={classNames(styles.content_wrapper, !panelOpen && styles.closed_panel_content_wrapper)}>
+          {!isPanelOpen && isMobile && mobileOpen}
+
+          <div className={classNames(styles.content_wrapper, !isPanelOpen && styles.closed_panel_content_wrapper)}>
             <Outlet />
           </div>
         </div>

--- a/frontend/src/PagesAdmin/AdminPageLayout/AdminPageLayout.module.scss
+++ b/frontend/src/PagesAdmin/AdminPageLayout/AdminPageLayout.module.scss
@@ -1,9 +1,33 @@
 @use 'src/constants' as *;
 
-@use 'src/mixins' as *;
+@use '../../mixins' as m;
+
+@use '../../styles/colors' as col;
 
 $page-padding: 2em;
 $header-bg-dark: #111111;
+
+.breadcrumb_bar {
+  width: 100%;
+  padding-left: 2rem;
+  background: col.$white-50;
+  border-bottom: 1px solid col.$gray-100;
+
+  @include m.theme-dark {
+    background: col.$gray-950;
+    border-color: col.$gray-800;
+  }
+}
+
+.wrapper {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.content {
+  overflow: auto;
+}
 
 .header {
   padding-top: 1em;
@@ -12,9 +36,9 @@ $header-bg-dark: #111111;
   background-color: $white;
   border-bottom: 1px solid $grey-4;
 
-  @include theme-dark {
+  @include m.theme-dark {
     background-color: $header-bg-dark;
-    border-color: $grey-0;
+    border-color: col.$gray-800;
     color: $white;
   }
 }

--- a/frontend/src/PagesAdmin/AdminPageLayout/AdminPageLayout.tsx
+++ b/frontend/src/PagesAdmin/AdminPageLayout/AdminPageLayout.tsx
@@ -21,32 +21,36 @@ export function AdminPageLayout({ title, backendUrl, header, loading, children }
   }, []);
 
   return (
-    <>
-      <div className={styles.header}>
+    <div className={styles.wrapper}>
+      <div className={styles.breadcrumb_bar}>
         <Breadcrumb />
-        <div className={styles.title_row}>
-          <div className={styles.title}>{title}</div>
-          {backendUrl && (
-            <IconButton
-              icon="vscode-icons:file-type-django"
-              title="Backend details"
-              target="backend"
-              color={COLORS.white}
-              border="solid #444 1px"
-              url={backendUrl}
-            />
-          )}
-        </div>
-        {header && <div className={styles.header_container}>{header}</div>}
       </div>
-      <div className={styles.content_container}>
-        {loading && (
-          <div className={styles.spinner_container}>
-            <SamfundetLogoSpinner />
+      <div className={styles.content}>
+        <div className={styles.header}>
+          <div className={styles.title_row}>
+            <div className={styles.title}>{title}</div>
+            {backendUrl && (
+              <IconButton
+                icon="vscode-icons:file-type-django"
+                title="Backend details"
+                target="backend"
+                color={COLORS.white}
+                border="solid #444 1px"
+                url={backendUrl}
+              />
+            )}
           </div>
-        )}
-        {!loading && children}
+          {header && <div className={styles.header_container}>{header}</div>}
+        </div>
+        <div className={styles.content_container}>
+          {loading && (
+            <div className={styles.spinner_container}>
+              <SamfundetLogoSpinner />
+            </div>
+          )}
+          {!loading && children}
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -27,6 +27,11 @@ export const XCSRFTOKEN = 'X-CSRFToken';
  */
 export const THEME_KEY = 'data-theme'; // Valid html tag attribute.
 
+/**
+ * Whether the control panel side panel is open or minimized.
+ */
+export const CONTROL_PANEL_SIDEPANEL_KEY = 'control-panel-sidepanel';
+
 export const SUPPORT_EMAIL = 'mg-web@samfundet.no';
 
 export const PHONENUMBER_REGEX = /^\+?\s*(\d\s*){8,15}$/;

--- a/frontend/src/hooks.ts
+++ b/frontend/src/hooks.ts
@@ -8,6 +8,7 @@ import { hasPerm, isTruthy, updateBodyThemeClass } from '~/utils';
 import type { LinkTarget } from './Components/Link/Link';
 import {
   BACKEND_DOMAIN,
+  CONTROL_PANEL_SIDEPANEL_KEY,
   PAGE_SIZE,
   THEME,
   THEME_KEY,
@@ -559,4 +560,22 @@ export function useSearchPaginatedQuery<T>({
     isLoading,
     error,
   };
+}
+
+/**
+ * Handles control panel sidepanel open/minimize state.
+ * Persisted in localStorage
+ */
+export function useSidePanelState(): [boolean, (open: boolean) => void] {
+  const isMobile = useMobile();
+  const [isOpen, setOpenState] = useState(
+    (localStorage.getItem(CONTROL_PANEL_SIDEPANEL_KEY) || 'open') === 'open' && !isMobile,
+  );
+
+  function setPanelOpen(open: boolean) {
+    localStorage.setItem(CONTROL_PANEL_SIDEPANEL_KEY, open ? 'open' : 'minimized');
+    setOpenState(open);
+  }
+
+  return [isOpen, setPanelOpen];
 }

--- a/frontend/src/styles/_colors.scss
+++ b/frontend/src/styles/_colors.scss
@@ -12,6 +12,12 @@ $uka-blue: #223A5E;
 
 $isfit-primary: #0099CC;
 
+$black-600: #232323;
+$black-700: #1C1C1C;
+$black-800: #111111;
+$black-900: #0A0A0A;
+$black-950: #030303;
+
 /// =~=~=~=~=~=~=~=~=~=~= ///
 /// Primary color palette ///
 /// =~=~=~=~=~=~=~=~=~=~= ///
@@ -37,7 +43,6 @@ $gray-500: #787373;
 $gray-600: #5F5B5B;
 $gray-700: #474444;
 $gray-800: #302E2E;
-$gray-850: #242323; // special in-between value
 $gray-900: #1B1919;
 $gray-950: #0E0D0D;
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,4 +1,5 @@
-import type { Dispatch, SetStateAction } from 'react';
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
+import type { UIMatch } from 'react-router';
 import type { buttonThemes } from '~/Components/Button/utils';
 import type { KV } from '~/constants';
 /** Module for global generic types. */
@@ -281,4 +282,12 @@ export interface CursorPaginatedResponse<T> {
   next: string | null; // URL or cursor for next page
   previous: string | null; // URL or cursor for previous page
   results: T[]; // Current page results
+}
+
+export type HandleWithCrumb = {
+  crumb: (match: UIMatch, data?: unknown) => ReactNode;
+};
+
+export interface MatchWithCrumb extends UIMatch {
+  handle: HandleWithCrumb;
 }


### PR DESCRIPTION
Makes the closed state of the side panel minimized instead of completely hidden. Persists the state in localStorage, so if a user minimizes it and reloads, it'll remain minimized.

### Desktop (sidebar open)

|Before|After|Before (dark)|After (dark)|
|---|---|---|---|
| <img width="1496" height="857" alt="Screenshot 2026-06-24 at 15 04 21" src="https://github.com/user-attachments/assets/ab74e707-60c3-4aa6-9215-91aeb2f5dffe" /> | <img width="1496" height="857" alt="Screenshot 2026-06-24 at 14 56 42" src="https://github.com/user-attachments/assets/eec6dcb4-ca96-41b4-a66c-10335e82776b" /> | <img width="1496" height="857" alt="Screenshot 2026-06-24 at 15 04 26" src="https://github.com/user-attachments/assets/830dbe63-a906-4430-b66a-604557a27234" /> | <img width="1496" height="857" alt="Screenshot 2026-06-24 at 14 57 12" src="https://github.com/user-attachments/assets/358695fa-b17c-471f-8eef-e030deeae596" />|

### Desktop (sidebar closed)

|Before|After|Before (dark)|After (dark)|
|---|---|---|---|
| <img width="1496" height="857" alt="Screenshot 2026-06-24 at 15 04 34" src="https://github.com/user-attachments/assets/0268fad1-bd64-4d08-a81f-451cabc71985" /> | <img width="1496" height="857" alt="Screenshot 2026-06-24 at 14 57 25" src="https://github.com/user-attachments/assets/d07b9014-4419-45e5-b67d-db80faf0696f" /> | <img width="1496" height="857" alt="Screenshot 2026-06-24 at 15 04 38" src="https://github.com/user-attachments/assets/d36046f1-fbdd-491e-9046-90a05f5cec4f" /> | <img width="1496" height="857" alt="Screenshot 2026-06-24 at 14 57 29" src="https://github.com/user-attachments/assets/53a19003-9d34-4a1d-8ec6-e63ac1f0089e" />

### Mobile (sidebar open)

|Before|After|Before (dark)|After (dark)|
|---|---|---|---|
|<img width="1296" height="2346" alt="Screen Shot 2026-06-24 at 15 04 50" src="https://github.com/user-attachments/assets/2eb6c0c2-4260-45f9-9c26-bdd2b8de99c4" /> | <img width="1296" height="2346" alt="Screen Shot 2026-06-24 at 15 05 48" src="https://github.com/user-attachments/assets/93818b24-51e9-4ba3-b9a9-84a4e0545ef8" /> | <img width="1296" height="2346" alt="Screen Shot 2026-06-24 at 15 05 01" src="https://github.com/user-attachments/assets/a947881a-e04c-4214-a3b3-262ec8b345cc" /> | <img width="1296" height="2346" alt="Screen Shot 2026-06-24 at 15 05 52" src="https://github.com/user-attachments/assets/19b534e2-a11c-4be9-9de6-2e934d9d7a80" />

### Mobile (sidebar closed)

|Before|After|Before (dark)|After (dark)|
|---|---|---|---|
|<img width="1296" height="2346" alt="Screen Shot 2026-06-24 at 15 04 46" src="https://github.com/user-attachments/assets/4ffd48de-cbcb-4be0-a913-c41899b63e0c" /> | <img width="1296" height="2346" alt="Screen Shot 2026-06-24 at 14 58 16" src="https://github.com/user-attachments/assets/e89370f5-1aec-4d8f-800c-143a2c5fba7d" />  | <img width="1296" height="2346" alt="Screen Shot 2026-06-24 at 15 04 56" src="https://github.com/user-attachments/assets/f2e80dc1-5250-4e06-8a3b-0fe0cbb6ec0d" /> | <img width="1296" height="2346" alt="Screen Shot 2026-06-24 at 14 59 00" src="https://github.com/user-attachments/assets/0eb49ed1-937f-4d41-9540-36edd887cab5" />






