### PR TITLE
Input style improvements & fixes

### DIFF
--- a/frontend/src/Components/Checkbox/Checkbox.module.scss
+++ b/frontend/src/Components/Checkbox/Checkbox.module.scss
@@ -1,8 +1,5 @@
-/* stylelint-disable selector-max-compound-selectors */
-@use 'src/constants' as *;
-$checkmark: '\2714'; /* ASCII "check"-symbol. */
+@use '../../styles/colors' as c;
 
-/* Label wraper i checkbox.tsx. */
 .checkbox {
   position: relative;
   display: inline-flex;
@@ -10,7 +7,6 @@ $checkmark: '\2714'; /* ASCII "check"-symbol. */
   cursor: pointer;
 }
 
-/* Selve input checkbox typen. */
 .checkbox__input {
   position: absolute;
   opacity: 0;
@@ -19,34 +15,39 @@ $checkmark: '\2714'; /* ASCII "check"-symbol. */
   width: 0;
 }
 
-/* Div som styles for å representere en checkbox. */
 .checkbox__box {
   width: 1.2em;
   height: 1.2em;
-  border: 2px solid $grey-3;
+  border: 2px solid c.$gray-400;
   border-radius: 3px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   margin-right: 10px;
   margin-left: 10px;
   flex-shrink: 0;
-  transition: background 0.15s, border-color 0.15s; /* Bakgrunn kommer gradvis inn. */
 }
 
-/* Her velges (og styles) det elementet med klassen .checkbox__box som ligger rett etter(ved bruk av +) elementet med klassen .checkbox__input, når det sistnevnte elementet er "checked". */
 .checkbox__input:checked + .checkbox__box {
-  background-color: $red-samf;
-  border-color: $red-samf;
+  background-color: c.$samf-red-primary;
+  border-color: c.$samf-red-primary;
 }
 
-.checkbox__input:checked + .checkbox__box::after {
+.check {
+  visibility: hidden;
+  font-size: 18px;
   color: white;
-  content: $checkmark;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  user-select: none;
+  pointer-events: none;
+}
+
+.checkbox__input:checked ~ .check {
+  visibility: visible;
 }
 
 .checkbox__input:disabled + .checkbox__box {
-  border-color: $grey-3;
-  background-color: $grey-3;
+  border-color: c.$gray-400;
+  background-color: c.$gray-400;
   cursor: not-allowed;
 }

--- a/frontend/src/Components/Checkbox/Checkbox.tsx
+++ b/frontend/src/Components/Checkbox/Checkbox.tsx
@@ -1,3 +1,4 @@
+import { Icon } from '@iconify/react';
 import classNames from 'classnames';
 import React from 'react';
 import styles from './Checkbox.module.scss';
@@ -47,6 +48,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
           {...props}
         />
         <div className={styles.checkbox__box} />
+        <Icon icon="fluent:checkmark-12-filled" className={styles.check} />
       </label>
     );
   },

--- a/frontend/src/Components/DatePicker/DatePicker.module.scss
+++ b/frontend/src/Components/DatePicker/DatePicker.module.scss
@@ -1,10 +1,8 @@
-@use 'sass:color';
+@use '../../constants' as c;
 
-/* stylelint-disable-next-line no-invalid-position-at-import-rule */
-@use 'src/constants' as *;
+@use '../../mixins' as m;
 
-/* stylelint-disable-next-line no-invalid-position-at-import-rule */
-@use 'src/mixins' as *;
+@use '../../styles/colors' as col;
 
 .container {
   position: relative;
@@ -12,49 +10,19 @@
 }
 
 .button {
-  @include rounded-lighter;
+  @include m.base-input;
   display: flex;
   gap: 0.25rem;
   align-items: center;
-  width: 100%;
   justify-content: flex-start;
-  font-size: 0.875rem;
-  padding: 0.75rem 2.5rem 0.75rem 1rem;
-  color: $black;
   cursor: pointer;
-  margin-top: 0.5em; // Make sure this is the same for all inputs that should be used together
-  border: 1px solid $grey-35;
-  background-color: $white;
-  font-weight: initial;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  transition: background-color 0.15s cubic-bezier(0.4, 0, 0.2, 1);
-
-  &:focus {
-    border-color: $grey-3;
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
-    outline: 1px solid rgba(0, 0, 0, 0.1);
-  }
-
-  @include theme-dark {
-    background-color: $theme-dark-input-bg;
-    color: white;
-    border-color: $grey-0;
-    &:focus {
-      border-color: $grey-1;
-      outline: 1px solid rgba(255, 255, 255, 0.6);
-    }
-    &:not(:disabled):hover {
-      background-color: color.scale($theme-dark-input-bg, $lightness: 8%);
-    }
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
 
   &:not(:disabled):hover {
-    background-color: $grey-4;
+    background: col.$gray-50;
+
+    @include m.theme-dark {
+      background: col.$black-600;
+    }
   }
 }
 
@@ -64,17 +32,15 @@
   top: 100%;
   margin-top: 4px;
   padding: 0.25rem;
-  background: $white;
+  background: col.$white-50;
   border-radius: 0.5rem;
   z-index: 100;
-  //box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   box-shadow: 0 4px 6px 0 rgba(0, 0, 0, 0.1);
-  //box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0.1) 0px 4px 6px -1px, rgba(0, 0, 0, 0.1) 0px 2px 4px -2px;
-  border: 1px solid $grey-35;
+  border: 1px solid col.$gray-200;
 
-  @include theme-dark {
-    background: $black-1;
-    border-color: $grey-0;
+  @include m.theme-dark {
+    background: col.$black-800;
+    border-color: col.$gray-800;
   }
 }
 

--- a/frontend/src/Components/DatePicker/DatePicker.tsx
+++ b/frontend/src/Components/DatePicker/DatePicker.tsx
@@ -1,6 +1,8 @@
 import { Icon } from '@iconify/react';
 import classNames from 'classnames';
 import { format } from 'date-fns';
+import enUS from 'date-fns/locale/en-US';
+import nb from 'date-fns/locale/nb';
 import { forwardRef, useMemo } from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -28,7 +30,8 @@ export const DatePicker = forwardRef<HTMLButtonElement, DatePickerProps>(
     const [date, setDate] = useState<Date | null>(null);
     const [open, setOpen] = useState(false);
 
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
+    const locale = i18n.language === 'nb' ? nb : enUS;
 
     const clickOutsideRef = useClickOutside<HTMLDivElement>(() => setOpen(false));
 
@@ -54,7 +57,7 @@ export const DatePicker = forwardRef<HTMLButtonElement, DatePickerProps>(
           ref={ref}
         >
           <Icon icon="material-symbols:calendar-month-outline-rounded" />
-          {value ? format(value, 'PPP') : <span>{label ?? t(KEY.pick_a_date)}</span>}
+          {value ? format(value, 'PPP', { locale }) : <span>{label ?? t(KEY.pick_a_date)}</span>}
         </button>
         <div className={classNames(styles.popover, !open && styles.hidden)}>
           <MiniCalendar

--- a/frontend/src/Components/Dropdown/Dropdown.module.scss
+++ b/frontend/src/Components/Dropdown/Dropdown.module.scss
@@ -1,12 +1,14 @@
-@use 'src/constants' as *;
+@use '../../mixins' as m;
 
-@use 'src/mixins' as *;
+@use '../../styles/colors' as col;
+
+@use '../../styles/variables' as v;
 
 .italic {
   font-style: italic;
+  font-family: v.$font-family-italic;
 }
 
-// label som wrapper
 .select_wrapper {
   display: flex;
   flex-direction: column;
@@ -15,45 +17,11 @@
 }
 
 .samf_select {
-  @include rounded-lighter;
+  @include m.base-input;
   display: flex;
-  font-size: 1em;
   padding: 0.75rem 2.5rem 0.75rem 1rem;
-  color: $black;
   cursor: pointer;
-  margin-top: 0.5em; // Make sure this is the same for all inputs that should be used together
-  border: 1px solid $grey-35;
-  background: $white;
-  font-weight: initial;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  appearance: none; // Hide default brower dropdown arrow
-
-  &:focus {
-    border-color: $grey-3;
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
-    outline: 1px solid rgba(0, 0, 0, 0.1);
-  }
-
-  @include theme-dark {
-    background: $theme-dark-input-bg;
-    color: $theme-dark-color;
-    border-color: $grey-0;
-    &:focus {
-      border-color: $grey-1;
-      outline: 1px solid rgba(255, 255, 255, 0.6);
-    }
-  }
-}
-
-.icon_disabled {
-  appearance: none; //appearance "none" i flere browsere
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  -ms-appearance: none;
-}
-
-.error {
-  border: 1px solid $red;
+  appearance: none; // Hide default browser dropdown arrow
 }
 
 .arrow_container {

--- a/frontend/src/Components/Dropdown/Dropdown.tsx
+++ b/frontend/src/Components/Dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@iconify/react';
 import { default as classNames, default as classnames } from 'classnames';
-import React, { type ChangeEvent, type ReactNode, useMemo } from 'react';
+import React, { type ChangeEvent, type ReactNode, useMemo, useState } from 'react';
 import styles from './Dropdown.module.scss';
 
 export type DropdownOption<T> = {
@@ -58,6 +58,8 @@ function DropdownInner<T>(
 ) {
   const isControlled = value !== undefined;
 
+  const [internalIndex, setInternalIndex] = useState(0);
+
   const finalOptions = useMemo<DropdownOption<T>[]>(() => {
     let opts = [...options];
 
@@ -87,12 +89,18 @@ function DropdownInner<T>(
     if (defaultValue !== undefined) {
       return finalOptions.findIndex((opt) => opt.value === defaultValue);
     }
+    if (!isControlled) {
+      return internalIndex;
+    }
     return 0; // fall back to selecting first element
-  }, [isControlled, value, defaultValue, finalOptions]);
+  }, [isControlled, value, defaultValue, finalOptions, internalIndex]);
 
   function handleChange(event: ChangeEvent<HTMLSelectElement>) {
     const index = Number.parseInt(event.currentTarget.value, 10);
     if (index >= 0 && index < finalOptions.length) {
+      if (!isControlled) {
+        setInternalIndex(index);
+      }
       onChange?.(finalOptions[index].value);
     }
   }
@@ -102,13 +110,10 @@ function DropdownInner<T>(
       {label}
       <select
         ref={ref}
-        className={classNames(
-          classNameSelect,
-          styles.samf_select,
-          !disableIcon && styles.icon_disabled,
-          error && styles.error,
-          nullOption && finalOptions[selectedIndex].value === finalOptions[0].value && styles.italic,
-        )}
+        className={classNames(classNameSelect, styles.samf_select, {
+          [styles.error]: error, // is defined by base-input mixin
+          [styles.italic]: nullOption && finalOptions[selectedIndex].value === finalOptions[0].value,
+        })}
         onChange={handleChange}
         disabled={disabled}
         defaultValue={!isControlled ? selectedIndex : undefined}

--- a/frontend/src/Components/EventQuery/EventQuery.module.scss
+++ b/frontend/src/Components/EventQuery/EventQuery.module.scss
@@ -12,6 +12,6 @@
   }
 }
 
-.searchBar {
-  margin: 0;
+.search {
+  flex: 1;
 }

--- a/frontend/src/Components/EventQuery/EventQuery.tsx
+++ b/frontend/src/Components/EventQuery/EventQuery.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { InputField } from '~/Components';
+import { Input } from '~/Components';
 import { KEY } from '~/i18n/constants';
 import type { EventCategoryValue, EventTicketTypeValue, SetState } from '~/types';
 import { getEventCategoryKey, getTicketTypeKey, lowerCapitalize } from '~/utils';
@@ -47,10 +47,11 @@ export function EventQuery({
 
   return (
     <div className={styles.queryBar}>
-      <InputField
-        onChange={setSearch}
+      <Input
+        type="text"
+        onChange={(e) => setSearch(e.target.value)}
         placeholder={t(KEY.common_search)}
-        labelClassName={styles.searchBar}
+        className={styles.search}
         icon="ic:baseline-search"
       />
       <Dropdown

--- a/frontend/src/Components/Input/Input.module.scss
+++ b/frontend/src/Components/Input/Input.module.scss
@@ -1,6 +1,6 @@
-@use 'src/constants' as *;
+@use '../../mixins' as m;
 
-@use 'src/mixins' as *;
+@use '../../styles/colors' as c;
 
 .date,
 .datetimeLocal,
@@ -14,40 +14,7 @@
 .time,
 .url,
 .week {
-  @include rounded-lighter;
-  padding: 0.75rem 1rem;
-  border: 1px solid $grey-35;
-  margin-top: 0.5em; // Make sure this is the same for all inputs that should be used together
-  outline: none;
-  font-weight: initial;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  width: 100%;
-  color: inherit;
-  background: $white;
-
-  &:focus {
-    border-color: $grey-3;
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
-    outline: 1px solid rgba(0, 0, 0, 0.1);
-  }
-
-  &.error {
-    border: 1px solid $red;
-  }
-
-  @include theme-dark {
-    background: $theme-dark-input-bg;
-    border-color: $grey-0;
-    &:focus {
-      border-color: $grey-1;
-      outline: 1px solid rgba(255, 255, 255, 0.6);
-    }
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
+  @include m.base-input;
 }
 
 /* stylelint-disable no-descending-specificity */
@@ -61,3 +28,28 @@
   }
 }
 /* stylelint-enable no-descending-specificity */
+
+.label {
+  position: relative;
+  flex: 1;
+  width: 100%;
+}
+
+.icon {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  font-size: 22px;
+  color: c.$gray-300;
+  transform: translateY(-50%);
+  user-select: none;
+  pointer-events: none;
+
+  @include m.theme-dark {
+    color: c.$gray-500;
+  }
+}
+
+.label:has(.icon) .input {
+  padding-right: 2rem;
+}

--- a/frontend/src/Components/Input/Input.tsx
+++ b/frontend/src/Components/Input/Input.tsx
@@ -1,3 +1,4 @@
+import { Icon } from '@iconify/react';
 import classNames from 'classnames';
 import React from 'react';
 import styles from './Input.module.scss';
@@ -8,6 +9,7 @@ import styles from './Input.module.scss';
 interface PrimitiveInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'defaultValue'> {
   className?: string;
   type?: React.HTMLInputTypeAttribute;
+  icon?: string;
 }
 
 /**
@@ -32,7 +34,7 @@ interface UncontrolledInputProps extends PrimitiveInputProps {
 export type InputProps = ControlledInputProps | UncontrolledInputProps;
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, value, defaultValue, ...props }, ref) => {
+  ({ className, type, value, defaultValue, icon, ...props }, ref) => {
     const isControlled = value !== undefined;
 
     // Optional: Map to specialized classNames based on `type`
@@ -52,15 +54,18 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     };
 
     return (
-      <input
-        ref={ref}
-        type={type}
-        className={classNames(styles.input, type && classMap[type], className)}
-        // If controlled, pass `value`, else pass `defaultValue`.
-        value={isControlled ? value : undefined}
-        defaultValue={!isControlled ? defaultValue : undefined}
-        {...props}
-      />
+      <label className={styles.label}>
+        <input
+          ref={ref}
+          type={type}
+          className={classNames(styles.input, type && classMap[type], className)}
+          // If controlled, pass `value`, else pass `defaultValue`.
+          value={isControlled ? value : undefined}
+          defaultValue={!isControlled ? defaultValue : undefined}
+          {...props}
+        />
+        {icon && <Icon icon={icon} className={styles.icon} />}
+      </label>
     );
   },
 );

--- a/frontend/src/Components/Textarea/Textarea.module.scss
+++ b/frontend/src/Components/Textarea/Textarea.module.scss
@@ -1,37 +1,7 @@
-@use 'src/constants' as *;
-
-@use 'src/mixins' as *;
+@use '../../mixins' as m;
 
 .textarea {
-  @include rounded-lighter;
-  padding: 0.75rem 1rem;
-  border: 1px solid $grey-35;
-  margin-top: 0.5em; // Make sure this is the same for all inputs that should be used together
-  outline: none;
-  font-weight: initial;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  width: 100%;
+  @include m.base-input;
   resize: vertical;
   min-height: 2.75rem;
-  background: $white;
-  color: $black;
-
-  &:focus {
-    border-color: $grey-3;
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
-    outline: 1px solid rgba(0, 0, 0, 0.1);
-  }
-  &.error {
-    border: 1px solid $red;
-  }
-
-  @include theme-dark {
-    background: $theme-dark-input-bg;
-    color: $theme-dark-color;
-    border-color: $grey-0;
-    &:focus {
-      border-color: $grey-1;
-      outline: 1px solid rgba(255, 255, 255, 0.6);
-    }
-  }
 }

--- a/frontend/src/Pages/ComponentPage/ExampleForm.tsx
+++ b/frontend/src/Pages/ComponentPage/ExampleForm.tsx
@@ -15,6 +15,7 @@ import {
   FormMessage,
   Input,
   NumberInput,
+  Textarea,
 } from '~/Components';
 import { PASSWORD, USERNAME } from '~/schema/user';
 
@@ -24,6 +25,7 @@ const schema = z.object({
   organization: z.string().nullish().optional(),
   duration: z.number().min(15).max(60),
   date: z.date(),
+  body: z.string(),
   confirm: z.boolean().refine((v) => v, 'Påkrevd'),
   image_file: z
     .instanceof(File)
@@ -44,6 +46,7 @@ export function ExampleForm() {
       password: '',
       organization: 'uka',
       duration: 15,
+      body: '',
       confirm: false,
       image_file: null,
     },
@@ -125,6 +128,19 @@ export function ExampleForm() {
               <FormLabel>Dato</FormLabel>
               <FormControl>
                 <DatePicker disabled={submitting} {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="body"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Melding</FormLabel>
+              <FormControl>
+                <Textarea disabled={submitting} {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/frontend/src/Pages/LoginPage/LoginForm.module.scss
+++ b/frontend/src/Pages/LoginPage/LoginForm.module.scss
@@ -13,3 +13,7 @@
   font-size: 0.9em;
   font-weight: 700;
 }
+
+.form_item {
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/Pages/LoginPage/LoginForm.tsx
+++ b/frontend/src/Pages/LoginPage/LoginForm.tsx
@@ -69,7 +69,7 @@ export function LoginForm() {
           name="username"
           disabled={isPending}
           render={({ field }) => (
-            <FormItem>
+            <FormItem className={styles.form_item}>
               <FormLabel>{t(KEY.common_username)}</FormLabel>
               <FormControl>
                 <Input type="text" {...field} />
@@ -83,7 +83,7 @@ export function LoginForm() {
           name="password"
           disabled={isPending}
           render={({ field }) => (
-            <FormItem>
+            <FormItem className={styles.form_item}>
               <FormLabel>{lowerCapitalize(t(KEY.common_password))}</FormLabel>
               <FormControl>
                 <Input type="password" {...field} />

--- a/frontend/src/_mixins.scss
+++ b/frontend/src/_mixins.scss
@@ -2,6 +2,10 @@
 /* Necessary for theme mixin */
 @use './constants' as *;
 
+@use './styles/colors' as col;
+
+@use './styles/variables' as v;
+
 /* Screen size media queries */
 // https://www.freecodecamp.org/news/the-100-correct-way-to-do-css-breakpoints-88d6a5ba1862/
 
@@ -187,4 +191,42 @@ Usage:
 @mixin flex-column-center {
   @include flex-column;
   justify-content: center;
+}
+
+@mixin base-input {
+  background: col.$white-50;
+  color: col.$gray-700;
+  border: 1px solid col.$gray-200;
+  padding: 0.75rem 1rem;
+  outline: none;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  font-weight: initial;
+  border-radius: 0.5rem;
+  width: 100%;
+
+  &:focus {
+    border-color: col.$gray-300;
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
+    outline: 1px solid rgba(0, 0, 0, 0.1);
+
+    @include theme-dark {
+      border-color: col.$gray-600;
+      outline: 1px solid rgba(255, 255, 255, 0.6);
+    }
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &.error {
+    border: 1px solid col.$red-600;
+  }
+
+  @include theme-dark {
+    background: col.$gray-950;
+    color: col.$white-50;
+    border-color: col.$gray-800;
+  }
 }

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -100,7 +100,6 @@ label {
   display: flex;
   flex-direction: column;
   font-weight: 600;
-  margin-bottom: 0.5em;
   color: col.$gray-950;
 }
 


### PR DESCRIPTION
Simplify various input style definitions. Create a `base-input` style mixin for helping with this.

* Checkbox
	* Replace ASCII character with icon from iconify, so we know it looks the same across all systems.
	* Remove bg and border transition. This made the checkbox feel somewhat sluggish.
	* The checkbox no longer shifts in the vertical axis when toggling.
* Dropdown
	* Fix bug with uncontrolled Dropdown components using nullOption, where all options would have italic styling, not just the null option.
 * DatePicker
	 * Use localized date in button instead of only english
 * Input
	 * Add `icon` prop for displaying an icon inside the input field, positioned to the right edge.