### PR TITLE
Improve login picker and login page

### DIFF
--- a/frontend/src/Pages/LoginPage/LoginForm.module.scss
+++ b/frontend/src/Pages/LoginPage/LoginForm.module.scss
@@ -1,17 +1,14 @@
-@use 'src/constants' as *;
-
-@use 'src/mixins' as *;
+@use '../../styles/colors' as c;
 
 .login_button {
   margin: 1rem 0 0 auto;
 }
 
 .login_failed_comment {
-  color: $red;
+  color: c.$red-600;
   text-align: center;
-  margin-top: 0.6em;
-  font-size: 0.9em;
-  font-weight: 700;
+  margin-top: 0.5rem;
+  font-weight: 500;
 }
 
 .form_item {

--- a/frontend/src/Pages/LoginPage/LoginPage.module.scss
+++ b/frontend/src/Pages/LoginPage/LoginPage.module.scss
@@ -1,6 +1,4 @@
-@use 'src/constants' as *;
-
-@use 'src/mixins' as *;
+@use '../../styles/variables' as v;
 
 .login_container {
   display: flex;
@@ -26,9 +24,9 @@
 
 .link {
   text-align: center;
-  margin-top: 0.6em;
-  font-size: 0.9em;
-  font-weight: 700;
+  margin-top: 0.5rem;
+  font-size: v.$font-size;
+  font-weight: 500;
   &:hover {
     text-decoration: underline;
   }

--- a/frontend/src/Pages/LoginPickerPage/LoginPickerPage.module.scss
+++ b/frontend/src/Pages/LoginPickerPage/LoginPickerPage.module.scss
@@ -1,12 +1,8 @@
-@use 'sass:color';
+@use '../../mixins' as m;
 
-@use 'src/constants' as *;
+@use '../../styles/variables' as v;
 
-@use 'src/mixins' as *;
-
-@use 'src/styles/variables' as v;
-
-@use 'src/styles/colors' as c;
+@use '../../styles/colors' as c;
 
 .container {
   max-width: 960px;
@@ -27,7 +23,7 @@
   margin-bottom: 5px;
   font-weight: 400;
 
-  @include theme-dark {
+  @include m.theme-dark {
     color: c.$gray-400;
   }
 }
@@ -37,12 +33,17 @@
   font-size: v.$font-size-4xl;
   font-weight: 600;
   margin-top: 0;
-  margin-bottom: 30px;
+  margin-bottom: 1rem;
   line-height: 1.1;
 
-  @include theme-dark {
+  @include m.theme-dark {
     color: c.$white-50;
   }
+}
+
+.page_description {
+  margin-bottom: 1.5rem;
+  line-height: 1.5rem;
 }
 
 .picker {
@@ -66,8 +67,8 @@
   font-family: inherit;
   text-decoration: none;
 
-  @include theme-dark {
-    background-color: $theme_dark_input_bg;
+  @include m.theme-dark {
+    background-color: c.$black-700;
     border-color: c.$gray-700;
   }
 
@@ -76,18 +77,17 @@
     color: inherit;
   }
 
-  @include theme-dark {
-    color: $white;
+  @include m.theme-dark {
+    color: c.$white-50;
   }
 
   &:hover {
     text-decoration: none;
-    border-color: $red_samf_hover;
-    background-color: $grey-5;
+    border-color: c.$samf-red-primary;
+    background-color: c.$white-950;
 
-    @include theme-dark {
-      background-color: $black-2;
-      border-color: $red_samf;
+    @include m.theme-dark {
+      background-color: c.$black-600;
     }
   }
 }
@@ -105,12 +105,20 @@
 
 .description {
   color: c.$gray-600;
-  font-size: 1.1rem;
-  font-weight: 300;
   margin: 0;
   line-height: 1.5;
 
-  @include theme-dark {
+  @include m.theme-dark {
+    color: c.$gray-400;
+  }
+}
+
+.description_note {
+  font-size: v.$font-size;
+  color: c.$gray-600;
+  margin-top: 0.25rem;
+
+  @include m.theme-dark {
     color: c.$gray-400;
   }
 }
@@ -131,25 +139,24 @@
   align-items: center;
   margin-top: 15px;
   margin-bottom: 25px;
-  color: $black-1;
+  color: c.$black-700;
   text-decoration: underline;
   text-underline-offset: 3px;
 
-  @include theme-dark {
-    color: $theme_dark_color;
+  @include m.theme-dark {
+    color: c.$gray-200;
   }
 
   &:hover {
-    color: $grey-1;
-    text-decoration-thickness: 2px;
+    color: c.$gray-400;
 
-    @include theme-dark {
-      color: $white;
+    @include m.theme-dark {
+      color: c.$white-50;
     }
   }
 
   &:focus-visible {
-    outline: 3px solid $orange-light;
+    outline: 3px solid c.$samf-red-primary;
     outline-offset: 2px;
   }
 }

--- a/frontend/src/Pages/LoginPickerPage/LoginPickerPage.tsx
+++ b/frontend/src/Pages/LoginPickerPage/LoginPickerPage.tsx
@@ -1,21 +1,13 @@
 import { Icon } from '@iconify/react';
-import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { Page } from '~/Components';
+import { Link, Page } from '~/Components';
 import { KEY } from '~/i18n/constants';
+import { ROUTES_FRONTEND } from '~/routes/frontend';
 import { SAMF3_LOGIN_URL } from '~/routes/samf-three';
 import styles from './LoginPickerPage.module.scss';
 
-type Props = { newRoute: string };
-
-/**
- * A page that allows users to choose between the old and new samf login.
- *
- * @param newRoute for the new samf login (samf4)
- * @constructor
- */
-export const LoginPickerPage: FC<Props> = ({ newRoute }) => {
+export function LoginPickerPage() {
   const navigate = useNavigate();
   const { t } = useTranslation();
 
@@ -28,22 +20,23 @@ export const LoginPickerPage: FC<Props> = ({ newRoute }) => {
         </button>
 
         <div className={styles.formWrapper}>
-          <span className={styles.caption}>{t(KEY.loginpicker_page_caption)}</span>
           <h1 className={styles.headerTitle}>{t(KEY.loginpicker_page_title)}</h1>
+          <p className={styles.page_description}>{t(KEY.loginpicker_page_description)}</p>
 
           <nav aria-label={t(KEY.loginpicker_page_nav_aria_label)} className={styles.picker}>
-            <a href={newRoute} className={styles.choiceWrapper}>
+            <Link url={ROUTES_FRONTEND.new_login} className={styles.choiceWrapper}>
               <div className={styles.textWrapper}>
                 <span className={styles.radioLabel}>{t(KEY.loginpicker_page_new_platform_title)}</span>
                 <p className={styles.description}>{t(KEY.loginpicker_page_new_platform_description)}</p>
               </div>
               <Icon icon="mdi:arrow-right" className={styles.arrowIcon} />
-            </a>
+            </Link>
 
             <a href={SAMF3_LOGIN_URL.login} className={styles.choiceWrapper}>
               <div className={styles.textWrapper}>
                 <span className={styles.radioLabel}>{t(KEY.loginpicker_page_old_platform_title)}</span>
                 <p className={styles.description}>{t(KEY.loginpicker_page_old_platform_description)}</p>
+                <p className={styles.description_note}>{t(KEY.loginpicker_page_old_platform_note)}</p>
               </div>
               <Icon icon="mdi:arrow-right" className={styles.arrowIcon} />
             </a>
@@ -52,4 +45,4 @@ export const LoginPickerPage: FC<Props> = ({ newRoute }) => {
       </div>
     </Page>
   );
-};
+}

--- a/frontend/src/i18n/constants.ts
+++ b/frontend/src/i18n/constants.ts
@@ -264,13 +264,14 @@ export const KEY = {
   signuppage_login_link: 'signuppage_login_link',
 
   // LoginPickerPage:
-  loginpicker_page_caption: 'loginpicker_page_caption',
   loginpicker_page_title: 'loginpicker_page_title',
+  loginpicker_page_description: 'loginpicker_page_description',
   loginpicker_page_nav_aria_label: 'loginpicker_page_nav_aria_label',
   loginpicker_page_new_platform_title: 'loginpicker_page_new_platform_title',
   loginpicker_page_new_platform_description: 'loginpicker_page_new_platform_description',
   loginpicker_page_old_platform_title: 'loginpicker_page_old_platform_title',
   loginpicker_page_old_platform_description: 'loginpicker_page_old_platform_description',
+  loginpicker_page_old_platform_note: 'loginpicker_page_old_platform_note',
 
   contributors_page_title: 'contributors_page_title',
   contributors_page_text: 'contributors_page_text',

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -244,7 +244,7 @@ export const nb = prepareTranslations({
   // LoginPage:
   [KEY.loginpage_register]: 'Lag bruker',
   [KEY.loginpage_login_failed]: 'Innlogging feilet',
-  [KEY.loginpage_internal_login]: 'Logg inn som intern',
+  [KEY.loginpage_internal_login]: 'Logg inn',
   [KEY.loginpage_passwords_must_match]: 'Passordene må være like',
   [KEY.loginpage_username]: 'Brukernavn',
   [KEY.loginpage_forgotten_password]: 'Glemt passordet ditt?',
@@ -253,13 +253,15 @@ export const nb = prepareTranslations({
   [KEY.signuppage_login_link]: 'Har du allerede en bruker?',
 
   // LoginPickerPage:
-  [KEY.loginpicker_page_caption]: 'Innlogging for interne',
-  [KEY.loginpicker_page_title]: 'Hvordan vil du logge inn?',
+  [KEY.loginpicker_page_title]: 'Hvor vil du logge inn?',
+  [KEY.loginpicker_page_description]:
+    'Vi jobber for tiden med å bygge en helt ny nettside for Samfundet.no. Funksjoner fra den gamle nettsiden vil gradvis bli tilgjengelige på den nye nettsiden, så foreløpig må du velge hvor du vil logge inn basert på hvilken funksjon du trenger.',
   [KEY.loginpicker_page_nav_aria_label]: 'Velg innlogging',
-  [KEY.loginpicker_page_new_platform_title]: 'Ny plattform (samf4)',
-  [KEY.loginpicker_page_new_platform_description]: 'Den nye plattformen for arrangementer og generell bruk',
-  [KEY.loginpicker_page_old_platform_title]: 'Eldre plattform (samf3)',
-  [KEY.loginpicker_page_old_platform_description]: 'Gruppeadministrasjon og andre administrative oppgaver',
+  [KEY.loginpicker_page_new_platform_title]: 'Ny nettside (samf4)',
+  [KEY.loginpicker_page_new_platform_description]: 'Arrangementer og generell bruk',
+  [KEY.loginpicker_page_old_platform_title]: 'Eldre nettside (samf3)',
+  [KEY.loginpicker_page_old_platform_description]: 'Gruppeadministrasjon, opptak, og andre administrative oppgaver.',
+  [KEY.loginpicker_page_old_platform_note]: 'NB: Kun tilgjengelig for frivillige',
 
   // ContributorsPage
   [KEY.contributors_page_title]: 'De frivillige som utvikler Samfundet.no',
@@ -956,7 +958,7 @@ export const en = prepareTranslations({
 
   // LoginPage:
   [KEY.loginpage_register]: 'Create user',
-  [KEY.loginpage_internal_login]: 'Log in as internal',
+  [KEY.loginpage_internal_login]: 'Log in',
   [KEY.loginpage_username]: 'Username',
   [KEY.loginpage_forgotten_password]: 'Forgot password?',
   [KEY.loginpage_passwords_must_match]: 'Passwords must match',
@@ -966,13 +968,15 @@ export const en = prepareTranslations({
   [KEY.signuppage_login_link]: 'Already have a user?',
 
   // LoginPickerPage:
-  [KEY.loginpicker_page_caption]: 'Internal login',
-  [KEY.loginpicker_page_title]: 'How would you like to log in?',
+  [KEY.loginpicker_page_title]: 'Where would you like to log in?',
+  [KEY.loginpicker_page_description]:
+    'We are currently building a brand new website for Samfundet.no. Features from the old website will gradually become available on the new one, so for now you need to choose where to log in based on which features you need.',
   [KEY.loginpicker_page_nav_aria_label]: 'Choose login',
-  [KEY.loginpicker_page_new_platform_title]: 'New platform (samf4)',
-  [KEY.loginpicker_page_new_platform_description]: 'The new platform for events and general use',
-  [KEY.loginpicker_page_old_platform_title]: 'Legacy platform (samf3)',
-  [KEY.loginpicker_page_old_platform_description]: 'Group administration and other administrative tasks',
+  [KEY.loginpicker_page_new_platform_title]: 'New site (samf4)',
+  [KEY.loginpicker_page_new_platform_description]: 'Events and general use',
+  [KEY.loginpicker_page_old_platform_title]: 'Legacy site (samf3)',
+  [KEY.loginpicker_page_old_platform_description]: 'Group administration, recruitment, and other administrative tasks.',
+  [KEY.loginpicker_page_old_platform_note]: 'NB: only available for volunteers',
 
   // GangsPage:
   [KEY.gangspage_title]: 'The groups at Samfundet',

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -122,14 +122,16 @@ export const router = createBrowserRouter(
           <Route path={ROUTES.frontend.health} element={<HealthPage />} />
           {import.meta.env.DEV && <Route path={ROUTES.frontend.components} element={<ComponentPage />} />}
           <Route element={<ProtectedRoute authState={false} element={<Outlet />} />}>
-            <Route path={ROUTES.frontend.login} element={<LoginPickerPage newRoute="/new-login" />} />
+            <Route path={ROUTES.frontend.login} element={<LoginPickerPage />} />
             <Route path={SAMF3_LOGIN_URL.login} element={<LoginPage />} />
             <Route handle={{ crumb: () => <Link url={ROUTES.frontend.login}>{t(KEY.common_login)}</Link> }}>
               <Route
                 path={ROUTES.frontend.new_login}
                 element={<LoginPage />}
                 handle={{
-                  crumb: ({ pathname }: UIMatch) => <Link url={pathname}>{t(KEY.loginpage_internal_login)}</Link>,
+                  crumb: ({ pathname }: UIMatch) => (
+                    <Link url={pathname}>{t(KEY.loginpicker_page_new_platform_title)}</Link>
+                  ),
                 }}
               />
             </Route>


### PR DESCRIPTION
Login picker:
- Get rid of "platform" term, it's confusing to regular users. Simply use "nettside" for Norwegian and "site" for English.
- Add a description explaining *why* users must pick between two logins.
- Add recruitment as a notable feature of the old site.
- Add a note to the description of the old site that it's only available to volunteers.

Login page (samf4):
- Get rid of the "Logg inn som intern" term, as this login is meant to be used by everyone, not just volunteers.
- Change breadcrumb to reflect actual location, instead of just "Logg inn > Logg inn"

Also did some small style tweaks.