### PR TITLE
Allow changing primary key field name in filter_queryset_by_permissions

### DIFF
--- a/backend/root/custom_classes/permission_classes.py
+++ b/backend/root/custom_classes/permission_classes.py
@@ -185,10 +185,11 @@ class RoleProtectedOrAnonReadOnlyObjectPermissions(RoleProtectedObjectPermission
     authenticated_users_only = False
 
 
-def filter_queryset_by_permissions(queryset: QuerySet, user: User, permission: str) -> QuerySet:
+def filter_queryset_by_permissions(queryset: QuerySet, user: User, permission: str, primary_key_field: str = 'id') -> QuerySet:
     """
     Filters a queryset based on user's permissions.
 
+    :param primary_key_field: The primary key field of the model, typically 'id' or 'slug'
     :param queryset: The original queryset to filter
     :param user: The user to check permissions for
     :param permission: Permission to check.
@@ -203,9 +204,9 @@ def filter_queryset_by_permissions(queryset: QuerySet, user: User, permission: s
         return queryset
 
     # If no model-level permission, filter by object-level permissions
-    permitted_ids = [obj.id for obj in queryset if user.has_perm(permission, obj)]
+    permitted_ids = [getattr(obj, primary_key_field) for obj in queryset if user.has_perm(permission, obj)]
 
-    return queryset.filter(id__in=permitted_ids)
+    return queryset.filter(**{f'{primary_key_field}__in': permitted_ids})
 
 
 class FeatureEnabled(BasePermission):


### PR DESCRIPTION
To allow models which for example use slugs as their primary key to also use this function