### PR TITLE
Change Dependabot to run quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,14 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/frontend" # Location of package manifests
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     labels:
       - "dependencies"
       - "frontend"
   - package-ecosystem: "uv"
     directory: "/backend"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     labels:
       - "dependencies"
       - "backend"


### PR DESCRIPTION
Instead of running monthly, will now run on the first day of each quarter (January, April, July, and October).